### PR TITLE
fix(linkedin-monitor): map authorFollowers from correct field instead…

### DIFF
--- a/packages/core/src/types/services.ts
+++ b/packages/core/src/types/services.ts
@@ -113,6 +113,7 @@ export interface LinkedInPost {
   authorName: string;
   authorHeadline?: string;
   authorUrl?: string;
+  authorFollowers?: number;
   likes: number;
   comments: number;
   shares?: number;

--- a/packages/nodes/src/integrations/social/linkedin-monitor.ts
+++ b/packages/nodes/src/integrations/social/linkedin-monitor.ts
@@ -170,7 +170,8 @@ export const linkedinMonitorNode = defineNode({
         authorName: post.authorName,
         authorHandle: extractHandleFromUrl(post.authorUrl),
         authorUrl: post.authorUrl || '',
-        authorFollowers: post.likes || 0,
+        // ForumScout may not always return follower data
+        authorFollowers: post.authorFollowers || 0,
         authorHeadline: post.authorHeadline,
         engagement: {
           likes: post.likes || 0,


### PR DESCRIPTION
… of likes

The LinkedIn monitor node was incorrectly mapping `post.likes` to `authorFollowers`, causing all posts to report follower count as their like count. Added `authorFollowers` as an optional field to the ForumScout LinkedInPost interface and updated the mapping to read the correct property with a fallback to 0.