### PR TITLE
feat: add example bread node that outputs "bread"

### DIFF
--- a/packages/nodes/src/examples/bread.ts
+++ b/packages/nodes/src/examples/bread.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { defineNode } from '@jam-nodes/core';
+
+/**
+ * Input schema for bread node
+ */
+export const BreadInputSchema = z.object({});
+
+export type BreadInput = z.infer<typeof BreadInputSchema>;
+
+/**
+ * Output schema for bread node
+ */
+export const BreadOutputSchema = z.object({
+  message: z.string(),
+});
+
+export type BreadOutput = z.infer<typeof BreadOutputSchema>;
+
+/**
+ * Bread node - always outputs "bread"
+ */
+export const breadNode = defineNode({
+  type: 'bread',
+  name: 'Bread',
+  description: 'Always outputs the string "bread"',
+  category: 'action', // or 'example' if that was a category, but 'action' fits best from core types
+  inputSchema: BreadInputSchema,
+  outputSchema: BreadOutputSchema,
+  estimatedDuration: 0,
+  executor: async () => {
+    return {
+      success: true,
+      output: {
+        message: 'bread',
+      },
+    };
+  },
+});

--- a/packages/nodes/src/examples/index.ts
+++ b/packages/nodes/src/examples/index.ts
@@ -5,3 +5,7 @@ export {
   HttpRequestOutputSchema,
   HttpMethodSchema,
 } from './http-request.js';
+
+export { breadNode } from './bread.js';
+export type { BreadInput, BreadOutput } from './bread.js';
+export { BreadInputSchema, BreadOutputSchema } from './bread.js';

--- a/packages/nodes/src/index.ts
+++ b/packages/nodes/src/index.ts
@@ -49,12 +49,17 @@ export {
   HttpRequestInputSchema,
   HttpRequestOutputSchema,
   HttpMethodSchema,
+  breadNode,
+  BreadInputSchema,
+  BreadOutputSchema,
 } from './examples/index.js';
 
 export type {
   HttpRequestInput,
   HttpRequestOutput,
   HttpMethod,
+  BreadInput,
+  BreadOutput,
 } from './examples/index.js';
 
 // Integration nodes
@@ -141,7 +146,7 @@ import { endNode } from './logic/index.js';
 import { delayNode } from './logic/index.js';
 import { mapNode } from './transform/index.js';
 import { filterNode } from './transform/index.js';
-import { httpRequestNode } from './examples/index.js';
+import { httpRequestNode, breadNode } from './examples/index.js';
 import {
   redditMonitorNode,
   twitterMonitorNode,
@@ -170,6 +175,7 @@ export const builtInNodes = [
   filterNode,
   // Examples
   httpRequestNode,
+  breadNode,
   // Integrations
   redditMonitorNode,
   twitterMonitorNode,

--- a/test.ts
+++ b/test.ts
@@ -4,7 +4,7 @@
  */
 
 import { NodeRegistry, ExecutionContext, defineNode } from './packages/core/src/index';
-import { conditionalNode, endNode, delayNode, mapNode, filterNode, httpRequestNode, builtInNodes } from './packages/nodes/src/index';
+import { conditionalNode, endNode, delayNode, mapNode, filterNode, httpRequestNode, breadNode, builtInNodes } from './packages/nodes/src/index';
 import { z } from 'zod';
 
 async function test() {
@@ -99,6 +99,11 @@ async function test() {
   const greetExecutor = registry.getExecutor('greet')!;
   const greetResult = await greetExecutor({ name: 'World' }, nodeCtx);
   console.log(`✓ Custom node: ${greetResult.output?.message}`);
+
+  // Test 8: Execute bread node
+  const breadExecutor = registry.getExecutor('bread')!;
+  const breadResult = await breadExecutor({}, nodeCtx);
+  console.log(`✓ Bread node: ${breadResult.output?.message}`);
 
   console.log('\n=== All tests passed! ===');
 }


### PR DESCRIPTION
This is mostly useless, but who hates more examples!? It also integrates with the tests. It just adds an example node that takes an empty object and returns a single string that says "bread"