### PR TITLE
fix: version bump for jam-nodes/core and jam-nodes/nodes to match packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -567,6 +567,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -645,7 +646,7 @@
     },
     "packages/core": {
       "name": "@jam-nodes/core",
-      "version": "0.1.2",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "jsonpath-plus": "^10.0.0"
@@ -660,10 +661,10 @@
     },
     "packages/nodes": {
       "name": "@jam-nodes/nodes",
-      "version": "0.1.3",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
-        "@jam-nodes/core": "^0.1.2"
+        "@jam-nodes/core": "^0.2.1"
       },
       "devDependencies": {
         "typescript": "^5.7.0",


### PR DESCRIPTION
This also marks node_modules/jsep as a peer dep as both "node_modules/@jsep-plugin/regex and node_modules/@jsep-plugin/assignment use jsep as a peer dep