### PR TITLE
feat: add retry node

### DIFF
--- a/packages/nodes/src/index.ts
+++ b/packages/nodes/src/index.ts
@@ -11,6 +11,8 @@ export {
   EndOutputSchema,
   DelayInputSchema,
   DelayOutputSchema,
+  RetryConfigSchema,
+  RetryMetadataSchema,
 } from './logic/index.js';
 
 export type {
@@ -22,6 +24,8 @@ export type {
   EndOutput,
   DelayInput,
   DelayOutput,
+  RetryConfig,
+  RetryMetadata,
 } from './logic/index.js';
 
 // Transform nodes
@@ -139,6 +143,7 @@ export type {
 import { conditionalNode } from './logic/index.js';
 import { endNode } from './logic/index.js';
 import { delayNode } from './logic/index.js';
+import { createRetryNode } from './logic/index.js';
 import { mapNode } from './transform/index.js';
 import { filterNode } from './transform/index.js';
 import { httpRequestNode } from './examples/index.js';
@@ -157,10 +162,14 @@ import {
   socialAiAnalyzeNode,
 } from './ai/index.js';
 
+export { createRetryNode };
+
+import type { NodeDefinition } from '@jam-nodes/core';
+
 /**
  * All built-in nodes as an array for easy registration
  */
-export const builtInNodes = [
+export const builtInNodes: NodeDefinition<any, any>[] = [
   // Logic
   conditionalNode,
   endNode,

--- a/packages/nodes/src/logic/index.ts
+++ b/packages/nodes/src/logic/index.ts
@@ -19,3 +19,7 @@ export { EndInputSchema, EndOutputSchema } from './end.js';
 export { delayNode } from './delay.js';
 export type { DelayInput, DelayOutput } from './delay.js';
 export { DelayInputSchema, DelayOutputSchema } from './delay.js';
+
+export { createRetryNode } from './retry.js';
+export type { RetryConfig, RetryMetadata } from './retry.js';
+export { RetryConfigSchema, RetryMetadataSchema } from './retry.js';

--- a/packages/nodes/src/logic/retry.ts
+++ b/packages/nodes/src/logic/retry.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+import { defineNode, type NodeDefinition } from '@jam-nodes/core';
+
+/**
+ * Configuration schema for retry functionality
+ */
+export const RetryConfigSchema = z.object({
+  /** Max retry attempts */
+  maxRetries: z.number().int().min(1).max(10).default(3),
+  /** Initial delay in milliseconds */
+  initialDelayMs: z.number().min(0).optional().default(1000),
+  /** Maximum delay cap in milliseconds */
+  maxDelayMs: z.number().min(0).optional().default(30000),
+  /** Exponential backoff multiplier */
+  backoffMultiplier: z.number().min(1).optional().default(2),
+});
+
+export type RetryConfig = z.infer<typeof RetryConfigSchema>;
+
+/**
+ * Metadata added to successful retry execution outputs
+ */
+export const RetryMetadataSchema = z.object({
+  retriesAttempted: z.number(),
+  totalDurationMs: z.number(),
+});
+
+export type RetryMetadata = z.infer<typeof RetryMetadataSchema>;
+
+/**
+ * Higher-order node factory that wraps an existing node definition
+ * with exponential backoff retry logic.
+ *
+ * @param node The node definition to wrap
+ * @returns A new node definition with retry configuration and metadata schemas merged
+ */
+export function createRetryNode<TInput, TOutput>(
+  node: NodeDefinition<TInput, TOutput>
+): NodeDefinition<TInput & RetryConfig, TOutput & RetryMetadata> {
+  return defineNode({
+    type: `${node.type}_with_retry`,
+    name: `${node.name} (Retry)`,
+    description: `Retries execution on failure. ${node.description}`,
+    category: node.category,
+
+    // Intersect the schemas
+    inputSchema: node.inputSchema.and(RetryConfigSchema) as unknown as z.ZodSchema<
+      TInput & RetryConfig
+    >,
+    outputSchema: node.outputSchema.and(RetryMetadataSchema) as unknown as z.ZodSchema<
+      TOutput & RetryMetadata
+    >,
+    capabilities: node.capabilities,
+
+    executor: async (input, context) => {
+      let attempt = 0;
+      const start = Date.now();
+      let lastError: string | undefined;
+
+      while (attempt <= input.maxRetries) {
+        try {
+          // input satisfies TInput because of the intersection
+          const result = await node.executor(input as unknown as TInput, context);
+
+          if (result.success && result.output !== undefined) {
+            return {
+              success: true,
+              output: {
+                ...result.output,
+                retriesAttempted: attempt,
+                totalDurationMs: Date.now() - start,
+              } as TOutput & RetryMetadata,
+            };
+          }
+
+          lastError = result.error;
+        } catch (error) {
+          lastError = error instanceof Error ? error.message : String(error);
+        }
+
+        if (attempt >= input.maxRetries) break;
+
+        const delay = Math.min(
+          (input.initialDelayMs || 1000) * Math.pow(input.backoffMultiplier || 2, attempt),
+          input.maxDelayMs || 30000
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        attempt++;
+      }
+
+      return {
+        success: false,
+        error: `Failed after ${attempt} attempts. Last error: ${lastError}`,
+      };
+    },
+  });
+}


### PR DESCRIPTION
Fixes #10 with a higher level `createRetryNode` node. This is unlike other nodes that define a `NodeDefinition`. `createRetryNode` has the header `createRetryNode<TInput, TOutput>(node: NodeDefinition<TInput, TOutput>): NodeDefinition<TInput & RetryConfig, TOutput & RetryMetadata>`.

It modifies the node config with 
```
return defineNode({
    type: `${node.type}_with_retry`,
    name: `${node.name} (Retry)`,
    description: `Retries execution on failure. ${node.description}`,
    category: node.category,
```
to avoid conflicts due to typing and does exponential backoff. It comes with some default backoff values. But most importantly, it is type safe! It fully uses Zod and when you're creating the retry version of a node, it retains type checking of the TInput for the node it is modifying.

To be fully honest this is not my favorite way of going about making this kind of node. I would recommend having configuration to the workflow that applies retries universally, or that each node has a config for retry. But if you really wanted to go towards something more complicated like wrapping nodes in nodes and composing them like this, you could could use a zod union to still have strict typing while wrapping a child node, but you honestly should not do that since it would loose all real practicality in maintaining the codebase.

Take this PR with a grain of salt. <3