### PR TITLE
feat: add an execution engine with configurable retry, caching, and timeout

### DIFF
--- a/packages/core/src/execution/execute-node.ts
+++ b/packages/core/src/execution/execute-node.ts
@@ -1,0 +1,150 @@
+import type { NodeDefinition, NodeExecutionContext, NodeExecutionResult } from '../types/node.js';
+import type { ExecutionConfig } from '../types/execution.js';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Execute a single node with optional retry, caching, and timeout.
+ *
+ * Input is validated against the node's inputSchema before execution.
+ * When caching is enabled, successful results are stored and returned
+ * on subsequent calls with the same input.
+ *
+ * @param node - The node definition to execute
+ * @param input - Raw input (validated against node.inputSchema)
+ * @param context - Execution context passed to the node executor
+ * @param config - Optional retry, cache, timeout, and signal configuration
+ */
+export async function executeNode<TInput, TOutput>(
+  node: NodeDefinition<TInput, TOutput>,
+  input: unknown,
+  context: NodeExecutionContext,
+  config?: ExecutionConfig,
+): Promise<NodeExecutionResult<TOutput>> {
+  const validatedInput = node.inputSchema.parse(input) as TInput;
+
+  if (config?.cache?.enabled) {
+    const { store, ttlMs, keyFn } = config.cache;
+    const cacheKey = (keyFn ?? defaultKeyFn)(validatedInput);
+    const cached = await store.get<NodeExecutionResult<TOutput>>(cacheKey);
+    if (cached) return cached;
+
+    const result = await executeWithRetry(node, validatedInput, context, config);
+
+    if (result.success) {
+      await store.set(cacheKey, result, ttlMs);
+    }
+
+    return result;
+  }
+
+  return executeWithRetry(node, validatedInput, context, config);
+}
+
+function defaultKeyFn(input: unknown): string {
+  return JSON.stringify(input);
+}
+
+async function executeWithRetry<TInput, TOutput>(
+  node: NodeDefinition<TInput, TOutput>,
+  input: TInput,
+  context: NodeExecutionContext,
+  config?: ExecutionConfig,
+): Promise<NodeExecutionResult<TOutput>> {
+  const maxAttempts = config?.retry?.maxAttempts ?? 1;
+  const backoffMs = config?.retry?.backoffMs ?? 0;
+  const backoffMultiplier = config?.retry?.backoffMultiplier ?? 2;
+  const maxBackoffMs = config?.retry?.maxBackoffMs ?? Infinity;
+  const retryOn = config?.retry?.retryOn;
+
+  let lastError: Error | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (config?.signal?.aborted) {
+      return { success: false, error: 'Execution aborted' };
+    }
+
+    try {
+      const result = await executeWithTimeout(node, input, context, config);
+
+      // A non-success result with an error is treated as a retriable failure
+      if (!result.success && result.error && attempt < maxAttempts) {
+        const error = new Error(result.error);
+        if (!retryOn || retryOn(error)) {
+          lastError = error;
+          config?.onRetry?.(attempt, error);
+          const delay = Math.min(backoffMs * Math.pow(backoffMultiplier, attempt - 1), maxBackoffMs);
+          await sleep(delay);
+          continue;
+        }
+      }
+
+      return result;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      lastError = error;
+
+      if (attempt < maxAttempts && (!retryOn || retryOn(error))) {
+        config?.onRetry?.(attempt, error);
+        const delay = Math.min(backoffMs * Math.pow(backoffMultiplier, attempt - 1), maxBackoffMs);
+        await sleep(delay);
+        continue;
+      }
+
+      return { success: false, error: error.message };
+    }
+  }
+
+  return { success: false, error: lastError?.message ?? 'Execution failed' };
+}
+
+async function executeWithTimeout<TInput, TOutput>(
+  node: NodeDefinition<TInput, TOutput>,
+  input: TInput,
+  context: NodeExecutionContext,
+  config?: ExecutionConfig,
+): Promise<NodeExecutionResult<TOutput>> {
+  const timeoutMs = config?.timeout;
+  const signal = config?.signal;
+
+  if (!timeoutMs && !signal) {
+    return node.executor(input, context);
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const promises: Promise<NodeExecutionResult<TOutput>>[] = [
+    node.executor(input, context),
+  ];
+
+  if (timeoutMs) {
+    promises.push(
+      new Promise<NodeExecutionResult<TOutput>>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`Execution timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    );
+  }
+
+  if (signal) {
+    promises.push(
+      new Promise<NodeExecutionResult<TOutput>>((_, reject) => {
+        if (signal.aborted) {
+          reject(new Error('Execution aborted'));
+          return;
+        }
+        signal.addEventListener('abort', () => reject(new Error('Execution aborted')), { once: true });
+      }),
+    );
+  }
+
+  try {
+    return await Promise.race(promises);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}

--- a/packages/core/src/execution/execute-workflow.ts
+++ b/packages/core/src/execution/execute-workflow.ts
@@ -1,0 +1,188 @@
+import type {
+  Workflow,
+  WorkflowExecutionConfig,
+  WorkflowExecutionResult,
+  NodeStatus,
+  ExecutionConfig,
+} from '../types/execution.js';
+import type { NodeExecutionResult } from '../types/node.js';
+import { ExecutionContext, prepareNodeInput } from './context.js';
+import { executeNode } from './execute-node.js';
+import { topologicalSort } from './topological-sort.js';
+
+/**
+ * Execute a workflow DAG with configurable retry, caching, and timeout.
+ *
+ * Nodes are executed in topologically-sorted waves. Independent nodes
+ * within the same wave run in parallel via Promise.allSettled().
+ * Each node's output is stored in the execution context so downstream
+ * nodes can reference it via {{nodeId.field}} interpolation.
+ *
+ * @param workflow - The workflow DAG to execute
+ * @param context - Execution context for variable interpolation and output storage
+ * @param config - Optional execution configuration with per-node overrides
+ */
+export async function executeWorkflow(
+  workflow: Workflow,
+  context: ExecutionContext,
+  config?: WorkflowExecutionConfig,
+): Promise<WorkflowExecutionResult> {
+  const waves = topologicalSort(workflow);
+  const workflowExecutionId = `wf_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+
+  const nodeMap = new Map(workflow.nodes.map((n) => [n.id, n]));
+  const statuses: Record<string, NodeStatus> = {};
+  const results: Record<string, NodeExecutionResult> = {};
+  const skippedNodes = new Set<string>();
+
+  // Build a map of downstream nodes for skip propagation
+  const downstreamOf = new Map<string, string[]>();
+  for (const edge of workflow.edges) {
+    const list = downstreamOf.get(edge.from) ?? [];
+    list.push(edge.to);
+    downstreamOf.set(edge.from, list);
+  }
+
+  // Build edge lookup for conditional branching
+  const edgesFrom = new Map<string, typeof workflow.edges>();
+  for (const edge of workflow.edges) {
+    const list = edgesFrom.get(edge.from) ?? [];
+    list.push(edge);
+    edgesFrom.set(edge.from, list);
+  }
+
+  for (const id of nodeMap.keys()) {
+    statuses[id] = 'idle';
+  }
+
+  for (const wave of waves) {
+    const wavePromises = wave.map(async (nodeId) => {
+      if (skippedNodes.has(nodeId)) {
+        statuses[nodeId] = 'skipped';
+        return;
+      }
+
+      if (config?.signal?.aborted) {
+        statuses[nodeId] = 'skipped';
+        return;
+      }
+
+      const workflowNode = nodeMap.get(nodeId);
+      if (!workflowNode) {
+        statuses[nodeId] = 'error';
+        results[nodeId] = { success: false, error: `Node "${nodeId}" not found in workflow` };
+        return;
+      }
+
+      statuses[nodeId] = 'running';
+      config?.onNodeStart?.(nodeId, workflowNode.type);
+
+      // Resolve per-node config: merge base config with node-specific overrides
+      const nodeConfig = resolveNodeConfig(config, workflowNode.type);
+
+      // Interpolate variables into the node input
+      const interpolatedInput = prepareNodeInput(workflowNode.input, context);
+
+      const nodeContext = context.toNodeContext(config?.userId ?? '', workflowExecutionId);
+
+      try {
+        const result = await executeNode(
+          workflowNode.node,
+          interpolatedInput,
+          nodeContext,
+          nodeConfig,
+        );
+
+        results[nodeId] = result as NodeExecutionResult;
+
+        if (result.success) {
+          statuses[nodeId] = 'success';
+          config?.onNodeComplete?.(nodeId, result as NodeExecutionResult);
+
+          if (result.output !== undefined) {
+            context.storeNodeOutput(nodeId, result.output);
+          }
+
+          // Handle conditional branching: skip branches not taken
+          if (result.nextNodeId) {
+            const edges = edgesFrom.get(nodeId) ?? [];
+            for (const edge of edges) {
+              if (edge.condition && edge.condition !== result.nextNodeId) {
+                skippedNodes.add(edge.to);
+                markDownstreamSkipped(edge.to, skippedNodes, downstreamOf);
+              }
+            }
+          }
+        } else {
+          statuses[nodeId] = 'error';
+          const error = new Error(result.error ?? 'Node execution failed');
+          config?.onNodeError?.(nodeId, error);
+
+          if (config?.stopOnError !== false) {
+            markDownstreamSkipped(nodeId, skippedNodes, downstreamOf);
+          }
+        }
+      } catch (err) {
+        statuses[nodeId] = 'error';
+        const error = err instanceof Error ? err : new Error(String(err));
+        results[nodeId] = { success: false, error: error.message };
+        config?.onNodeError?.(nodeId, error);
+
+        if (config?.stopOnError !== false) {
+          markDownstreamSkipped(nodeId, skippedNodes, downstreamOf);
+        }
+      }
+    });
+
+    await Promise.allSettled(wavePromises);
+  }
+
+  const allStatuses = Object.values(statuses);
+  const success = allStatuses.every((s) => s === 'success' || s === 'skipped');
+
+  return { success, results, statuses };
+}
+
+function resolveNodeConfig(
+  config: WorkflowExecutionConfig | undefined,
+  nodeType: string,
+): ExecutionConfig | undefined {
+  if (!config) return undefined;
+
+  const override = config.nodeConfig?.[nodeType];
+  if (!override) {
+    return extractBaseConfig(config);
+  }
+
+  const base = extractBaseConfig(config);
+  return {
+    ...base,
+    ...override,
+    retry: override.retry ?? base?.retry,
+    cache: override.cache ?? base?.cache,
+  };
+}
+
+function extractBaseConfig(config: WorkflowExecutionConfig): ExecutionConfig {
+  return {
+    retry: config.retry,
+    cache: config.cache,
+    timeout: config.timeout,
+    signal: config.signal,
+    onRetry: config.onRetry,
+  };
+}
+
+function markDownstreamSkipped(
+  nodeId: string,
+  skippedNodes: Set<string>,
+  downstreamOf: Map<string, string[]>,
+): void {
+  const queue = downstreamOf.get(nodeId) ?? [];
+  for (const downstream of queue) {
+    if (!skippedNodes.has(downstream)) {
+      skippedNodes.add(downstream);
+      markDownstreamSkipped(downstream, skippedNodes, downstreamOf);
+    }
+  }
+}

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -3,3 +3,7 @@ export {
   createExecutionContext,
   prepareNodeInput,
 } from './context.js';
+
+export { executeNode } from './execute-node.js';
+export { executeWorkflow } from './execute-workflow.js';
+export { MemoryCacheStore } from './memory-cache.js';

--- a/packages/core/src/execution/memory-cache.ts
+++ b/packages/core/src/execution/memory-cache.ts
@@ -1,0 +1,37 @@
+import type { CacheStore } from '../types/execution.js';
+
+interface CacheEntry {
+  value: unknown;
+  expireAt: number;
+}
+
+/**
+ * Simple in-memory cache store backed by a Map.
+ * Expired entries are lazily evicted on read.
+ */
+export class MemoryCacheStore implements CacheStore {
+  private cache = new Map<string, CacheEntry>();
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const entry = this.cache.get(key);
+    if (!entry) return undefined;
+
+    if (Date.now() > entry.expireAt) {
+      this.cache.delete(key);
+      return undefined;
+    }
+
+    return entry.value as T;
+  }
+
+  async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    this.cache.set(key, {
+      value,
+      expireAt: Date.now() + ttlMs,
+    });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.cache.delete(key);
+  }
+}

--- a/packages/core/src/execution/topological-sort.ts
+++ b/packages/core/src/execution/topological-sort.ts
@@ -1,0 +1,59 @@
+import type { Workflow } from '../types/execution.js';
+
+/**
+ * Kahn's algorithm returning nodes grouped into execution waves.
+ * Each wave contains node IDs whose dependencies are fully satisfied,
+ * meaning all nodes within a wave can run in parallel.
+ *
+ * @throws Error if the workflow graph contains a cycle.
+ */
+export function topologicalSort(workflow: Workflow): string[][] {
+  const nodeIds = new Set(workflow.nodes.map((n) => n.id));
+  const inDegree = new Map<string, number>();
+  const adjacency = new Map<string, string[]>();
+
+  for (const id of nodeIds) {
+    inDegree.set(id, 0);
+    adjacency.set(id, []);
+  }
+
+  for (const edge of workflow.edges) {
+    adjacency.get(edge.from)!.push(edge.to);
+    inDegree.set(edge.to, (inDegree.get(edge.to) ?? 0) + 1);
+  }
+
+  const waves: string[][] = [];
+  let queue: string[] = [];
+
+  for (const [id, degree] of inDegree) {
+    if (degree === 0) {
+      queue.push(id);
+    }
+  }
+
+  let processed = 0;
+
+  while (queue.length > 0) {
+    waves.push(queue);
+    const nextQueue: string[] = [];
+
+    for (const id of queue) {
+      processed++;
+      for (const neighbor of adjacency.get(id)!) {
+        const newDegree = (inDegree.get(neighbor) ?? 0) - 1;
+        inDegree.set(neighbor, newDegree);
+        if (newDegree === 0) {
+          nextQueue.push(neighbor);
+        }
+      }
+    }
+
+    queue = nextQueue;
+  }
+
+  if (processed !== nodeIds.size) {
+    throw new Error('Workflow graph contains a cycle');
+  }
+
+  return waves;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,17 @@ export type {
   ResolvedCredentials,
   CredentialProvider,
   CredentialRegistry,
+  // Execution engine types
+  RetryConfig,
+  CacheStore,
+  CacheConfig,
+  ExecutionConfig,
+  WorkflowExecutionConfig,
+  WorkflowExecutionResult,
+  Workflow,
+  WorkflowNode,
+  WorkflowEdge,
+  NodeStatus,
 } from './types/index.js';
 
 // Credential helpers
@@ -58,11 +69,14 @@ export {
   defineBasicCredential,
 } from './types/index.js';
 
-// Execution context
+// Execution
 export {
   ExecutionContext,
   createExecutionContext,
   prepareNodeInput,
+  executeNode,
+  executeWorkflow,
+  MemoryCacheStore,
 } from './execution/index.js';
 
 // Registry

--- a/packages/core/src/types/execution.ts
+++ b/packages/core/src/types/execution.ts
@@ -1,0 +1,115 @@
+import type { NodeDefinition, NodeExecutionResult } from './node.js';
+
+/**
+ * Configuration for retry behavior on node execution failure.
+ */
+export interface RetryConfig {
+  /** Maximum number of execution attempts */
+  maxAttempts: number;
+  /** Initial delay between retries in milliseconds */
+  backoffMs: number;
+  /** Multiplier applied to backoffMs after each retry (default: 2) */
+  backoffMultiplier?: number;
+  /** Upper bound on backoff delay in milliseconds */
+  maxBackoffMs?: number;
+  /** Predicate to decide whether a given error should trigger a retry */
+  retryOn?: (error: Error) => boolean;
+}
+
+/**
+ * Interface for pluggable cache backends.
+ * Implement this to use Redis, Memcached, or any other store.
+ */
+export interface CacheStore {
+  get<T>(key: string): Promise<T | undefined>;
+  set<T>(key: string, value: T, ttlMs: number): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+/**
+ * Configuration for caching node execution results.
+ */
+export interface CacheConfig {
+  /** Whether caching is active */
+  enabled: boolean;
+  /** Time-to-live for cached entries in milliseconds */
+  ttlMs: number;
+  /** Custom function to derive a cache key from the node input */
+  keyFn?: (input: unknown) => string;
+  /** Cache backend to use */
+  store: CacheStore;
+}
+
+/**
+ * Configuration for a single node execution.
+ * Controls retry, caching, timeout, and cancellation.
+ */
+export interface ExecutionConfig {
+  retry?: RetryConfig;
+  cache?: CacheConfig;
+  /** Maximum execution time per attempt in milliseconds */
+  timeout?: number;
+  /** AbortSignal for cancellation */
+  signal?: AbortSignal;
+  /** Called after each failed attempt before the next retry */
+  onRetry?: (attempt: number, error: Error) => void;
+}
+
+/**
+ * Configuration for workflow execution.
+ * Extends ExecutionConfig with per-node overrides and lifecycle callbacks.
+ */
+export interface WorkflowExecutionConfig extends ExecutionConfig {
+  /** User ID passed to each node's execution context */
+  userId?: string;
+  /** Per-node-type config overrides (keyed by node type, e.g. 'http_request') */
+  nodeConfig?: Record<string, Partial<ExecutionConfig>>;
+  /** If true (default), downstream nodes are skipped when a node fails */
+  stopOnError?: boolean;
+  onNodeStart?: (nodeId: string, nodeType: string) => void;
+  onNodeComplete?: (nodeId: string, result: NodeExecutionResult) => void;
+  onNodeError?: (nodeId: string, error: Error) => void;
+}
+
+/** Lifecycle state of a node during workflow execution. */
+export type NodeStatus = 'idle' | 'running' | 'success' | 'error' | 'skipped';
+
+/** A node instance within a workflow DAG. */
+export interface WorkflowNode {
+  /** Unique identifier for this node within the workflow */
+  id: string;
+  /** Node type (e.g. 'http_request'), used to match nodeConfig keys */
+  type: string;
+  /** The node definition containing the executor */
+  node: NodeDefinition;
+  /** Raw input to pass to the node (supports {{variable}} interpolation) */
+  input: Record<string, unknown>;
+}
+
+/** A directed edge between two nodes in the workflow DAG. */
+export interface WorkflowEdge {
+  from: string;
+  to: string;
+  /** When set, this edge is only followed if the source node's nextNodeId matches */
+  condition?: string;
+}
+
+/** A directed acyclic graph of workflow nodes. */
+export interface Workflow {
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  /** ID of the root node (used for documentation; execution order is derived from edges) */
+  entryNodeId: string;
+}
+
+/** Aggregate result returned by executeWorkflow. */
+export interface WorkflowExecutionResult {
+  /** True if every non-skipped node succeeded */
+  success: boolean;
+  /** Individual result for each node, keyed by node ID */
+  results: Record<string, NodeExecutionResult>;
+  /** Final status of each node, keyed by node ID */
+  statuses: Record<string, NodeStatus>;
+  /** Workflow-level error message, if any */
+  error?: string;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -62,3 +62,16 @@ export {
   defineBearerCredential,
   defineBasicCredential,
 } from './credentials.js';
+
+export type {
+  RetryConfig,
+  CacheStore,
+  CacheConfig,
+  ExecutionConfig,
+  WorkflowExecutionConfig,
+  WorkflowExecutionResult,
+  Workflow,
+  WorkflowNode,
+  WorkflowEdge,
+  NodeStatus,
+} from './execution.js';

--- a/test.ts
+++ b/test.ts
@@ -3,7 +3,8 @@
  * Run with: npx tsx test.ts
  */
 
-import { NodeRegistry, ExecutionContext, defineNode } from './packages/core/src/index';
+import { NodeRegistry, ExecutionContext, defineNode, executeNode, executeWorkflow, MemoryCacheStore } from './packages/core/src/index';
+import type { Workflow } from './packages/core/src/index';
 import { conditionalNode, endNode, delayNode, mapNode, filterNode, sortNode, httpRequestNode, breadNode, builtInNodes } from './packages/nodes/src/index';
 import { z } from 'zod';
 
@@ -115,6 +116,169 @@ async function test() {
   const breadExecutor = registry.getExecutor('bread')!;
   const breadResult = await breadExecutor({}, nodeCtx);
   console.log(`✓ Bread node: ${breadResult.output?.message}`);
+
+  console.log('\n=== Testing execution engine ===\n');
+
+  // Test 9: Execute Node Bread
+  const execResult = await executeNode(breadNode, {}, nodeCtx);
+  console.log(`✓ Execute Node Bread: success=${execResult.success}, output=${JSON.stringify(execResult.output)}`);
+
+  // Test 10: Execute Node Bread With Cache
+  const cacheStore = new MemoryCacheStore();
+  const cached1 = await executeNode(breadNode, {}, nodeCtx, {
+    cache: { enabled: true, ttlMs: 5000, store: cacheStore },
+  });
+  const cached2 = await executeNode(breadNode, {}, nodeCtx, {
+    cache: { enabled: true, ttlMs: 5000, store: cacheStore },
+  });
+  console.log(`✓ Execute Node Bread With Cache: first=${cached1.success}, second=${cached2.success} (cache hit)`);
+
+  // Test 11: Execute Node with Retry
+  let attemptCount = 0;
+  const failTwiceNode = defineNode({
+    type: 'fail_twice',
+    name: 'Fail Twice',
+    description: 'Fails the first 2 attempts, succeeds on 3rd',
+    category: 'action',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ attempt: z.number() }),
+    executor: async () => {
+      attemptCount++;
+      if (attemptCount < 3) {
+        return { success: false, error: `Fail #${attemptCount}` };
+      }
+      return { success: true, output: { attempt: attemptCount } };
+    },
+  });
+
+  const retries: number[] = [];
+  const retryResult = await executeNode(failTwiceNode, {}, nodeCtx, {
+    retry: { maxAttempts: 3, backoffMs: 10 },
+    onRetry: (attempt) => retries.push(attempt),
+  });
+  console.log(`✓ Execute Node with Retry: success=${retryResult.success}, retries=${retries.join(',')}, finalAttempt=${retryResult.output?.attempt}`);
+
+  // Test 12: Execute Node with Timeout
+  const slowNode = defineNode({
+    type: 'slow',
+    name: 'Slow',
+    description: 'Takes 500ms',
+    category: 'action',
+    inputSchema: z.object({}),
+    outputSchema: z.object({}),
+    executor: async () => {
+      await new Promise((r) => setTimeout(r, 500));
+      return { success: true, output: {} };
+    },
+  });
+
+  const timeoutResult = await executeNode(slowNode, {}, nodeCtx, { timeout: 50 });
+  console.log(`✓ Execute Node with Timeout: success=${timeoutResult.success}, error="${timeoutResult.error}"`);
+
+  // Test 13: Execute Workflow
+  console.log('\n=== Testing executeWorkflow ===\n');
+
+  const stepA = defineNode({
+    type: 'step_a',
+    name: 'Step A',
+    description: 'First step',
+    category: 'action',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ value: z.string() }),
+    executor: async () => ({ success: true, output: { value: 'from-A' } }),
+  });
+
+  const stepB = defineNode({
+    type: 'step_b',
+    name: 'Step B',
+    description: 'Second step, reads from A',
+    category: 'action',
+    inputSchema: z.object({ upstream: z.string().optional() }),
+    outputSchema: z.object({ value: z.string() }),
+    executor: async (input) => ({
+      success: true,
+      output: { value: `from-B(${input.upstream ?? 'none'})` },
+    }),
+  });
+
+  const workflow: Workflow = {
+    entryNodeId: 'a',
+    nodes: [
+      { id: 'a', type: 'step_a', node: stepA, input: {} },
+      { id: 'b', type: 'step_b', node: stepB, input: { upstream: '{{a.value}}' } },
+      { id: 'done', type: 'end', node: endNode, input: { message: 'finished' } },
+    ],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'done' },
+    ],
+  };
+
+  const wfCtx = new ExecutionContext();
+  const events: string[] = [];
+  const wfResult = await executeWorkflow(workflow, wfCtx, {
+    onNodeStart: (id) => events.push(`start:${id}`),
+    onNodeComplete: (id) => events.push(`done:${id}`),
+  });
+
+  console.log(`✓ Execute Workflow: success=${wfResult.success}`);
+  console.log(`  statuses: ${JSON.stringify(wfResult.statuses)}`);
+  console.log(`  events: ${events.join(' → ')}`);
+  console.log(`  step B output: ${JSON.stringify(wfResult.results['b']?.output)}`);
+
+  // Test 14: Execute Workflow with Conditional Branching
+  const workflow2: Workflow = {
+    entryNodeId: 'check',
+    nodes: [
+      {
+        id: 'check', type: 'conditional', node: conditionalNode,
+        input: {
+          condition: { type: 'equals', variableName: 'flag', value: true },
+          trueNodeId: 'yes-end',
+          falseNodeId: 'no-end',
+        },
+      },
+      { id: 'yes-end', type: 'end', node: endNode, input: { message: 'took yes branch' } },
+      { id: 'no-end', type: 'end', node: endNode, input: { message: 'took no branch' } },
+    ],
+    edges: [
+      { from: 'check', to: 'yes-end', condition: 'yes-end' },
+      { from: 'check', to: 'no-end', condition: 'no-end' },
+    ],
+  };
+
+  const wfCtx2 = new ExecutionContext({ flag: true });
+  const wfResult2 = await executeWorkflow(workflow2, wfCtx2);
+  console.log(`✓ Execute Workflow (Conditional): success=${wfResult2.success}`);
+  console.log(`  statuses: ${JSON.stringify(wfResult2.statuses)}`);
+
+  // Test 15: Execute Workflow with Failing Node
+  const failingNode = defineNode({
+    type: 'always_fail',
+    name: 'Always Fail',
+    description: 'Always fails',
+    category: 'action',
+    inputSchema: z.object({}),
+    outputSchema: z.object({}),
+    executor: async () => ({ success: false, error: 'Something went wrong' }),
+  });
+
+  const workflow3: Workflow = {
+    entryNodeId: 'fail-step',
+    nodes: [
+      { id: 'fail-step', type: 'always_fail', node: failingNode, input: {} },
+      { id: 'after-fail', type: 'end', node: endNode, input: { message: 'should be skipped' } },
+    ],
+    edges: [
+      { from: 'fail-step', to: 'after-fail' },
+    ],
+  };
+
+  const wfCtx3 = new ExecutionContext();
+  const wfResult3 = await executeWorkflow(workflow3, wfCtx3);
+  console.log(`✓ Execute Workflow (Failing): success=${wfResult3.success}`);
+  console.log(`  statuses: ${JSON.stringify(wfResult3.statuses)}`);
+  console.log(`  error: ${wfResult3.results['fail-step']?.error}`);
 
   console.log('\n=== All tests passed! ===');
 }


### PR DESCRIPTION
closes #37 

added:
- Add executeNode() for single node execution with configurable retry,
  caching, timeout, and AbortSignal support
- Add executeWorkflow() for DAG execution with wave-based parallelism,
  conditional branching, and per-node config overrides
- Add MemoryCacheStore as default in-memory CacheStore implementation
- Add topological sort (Kahn's algorithm) for workflow DAG traversal
- Add execution engine tests to test.ts file

tried my best to incorporate all requirements. If i missed something, or if something needs to be explained let me know. Pretty straightforward approach. MemoryCachStore is using a simple map. I added a `userId` optional field on the `WorkflowExecutionConfig` since it is required by `NodeExecutionContext`. 
