### PR TITLE
feat: add Dev.to integration (devtoCreateArticle, devtoUpdateArticle, devtoGetArticles)

### DIFF
--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -1,5 +1,5 @@
-import type { z } from 'zod';
-import type { NodeServices } from './services.js';
+import type { z } from 'zod'
+import type { NodeServices } from './services.js'
 
 /**
  * Credentials for API authentication.
@@ -8,44 +8,48 @@ import type { NodeServices } from './services.js';
 export interface NodeCredentials {
   /** Apollo.io API credentials */
   apollo?: {
-    apiKey: string;
-  };
+    apiKey: string
+  }
   /** Firecrawl API credentials  */
   firecrawl?: {
-    bearerToken?: string;
+    bearerToken?: string
   }
   /** Twitter/X API credentials */
   twitter?: {
     /** Official Twitter API v2 Bearer Token */
-    bearerToken?: string;
+    bearerToken?: string
     /** TwitterAPI.io API key (third-party, simpler) */
-    twitterApiIoKey?: string;
-  };
+    twitterApiIoKey?: string
+  }
   /** ForumScout API credentials (for LinkedIn monitoring) */
   forumScout?: {
-    apiKey: string;
-  };
+    apiKey: string
+  }
   /** DataForSEO API credentials */
   dataForSeo?: {
     /** Base64 encoded login:password */
-    apiToken: string;
-  };
+    apiToken: string
+  }
   /** OpenAI API credentials */
   openai?: {
-    apiKey: string;
-  };
+    apiKey: string
+  }
   /** Anthropic API credentials */
   anthropic?: {
-    apiKey: string;
-  };
+    apiKey: string
+  }
   /** Discord Bot credentials */
   discordBot?: {
-    botToken: string;
-  };
+    botToken: string
+  }
   /** Discord Webhook credentials */
   discordWebhook?: {
-    webhookUrl: string;
-  };
+    webhookUrl: string
+  }
+  /** Dev.to API credentials */
+  devto?: {
+    apiKey: string
+  }
 }
 
 /**
@@ -54,22 +58,22 @@ export interface NodeCredentials {
  */
 export interface NodeExecutionContext {
   /** User ID executing the workflow */
-  userId: string;
+  userId: string
   /** Optional campaign/project context */
-  campaignId?: string;
+  campaignId?: string
   /** Unique identifier for this workflow execution */
-  workflowExecutionId: string;
+  workflowExecutionId: string
   /** Variables from previous node outputs */
-  variables: Record<string, unknown>;
+  variables: Record<string, unknown>
   /** Resolve nested path like "contact.email" or "data[0].name" */
-  resolveNestedPath: (path: string) => unknown;
+  resolveNestedPath: (path: string) => unknown
   /** API credentials for direct HTTP calls */
-  credentials?: NodeCredentials;
+  credentials?: NodeCredentials
   /**
    * Optional services injected by host application.
    * @deprecated Use credentials instead for standalone operation.
    */
-  services?: NodeServices;
+  services?: NodeServices
 }
 
 /**
@@ -77,13 +81,13 @@ export interface NodeExecutionContext {
  */
 export interface NodeApprovalRequest {
   /** IDs of resources needing approval */
-  resourceIds: string[];
+  resourceIds: string[]
   /** Type of resource for UI display */
-  resourceType: string;
+  resourceType: string
   /** Optional message to display to approver */
-  message?: string;
+  message?: string
   /** Component to use for displaying approval details */
-  detailComponent?: string;
+  detailComponent?: string
 }
 
 /**
@@ -92,21 +96,21 @@ export interface NodeApprovalRequest {
  */
 export interface NodeExecutionResult<TOutput = unknown> {
   /** Whether execution succeeded */
-  success: boolean;
+  success: boolean
   /** Output data on success */
-  output?: TOutput;
+  output?: TOutput
   /** Error message on failure */
-  error?: string;
+  error?: string
   /** Next node ID for conditional branching */
-  nextNodeId?: string;
+  nextNodeId?: string
   /** Approval request if node needs user approval */
-  needsApproval?: NodeApprovalRequest;
+  needsApproval?: NodeApprovalRequest
   /** Notification to send to user */
   notification?: {
-    title: string;
-    message: string;
-    data?: Record<string, unknown>;
-  };
+    title: string
+    message: string
+    data?: Record<string, unknown>
+  }
 }
 
 /**
@@ -117,46 +121,46 @@ export interface NodeExecutionResult<TOutput = unknown> {
  */
 export type NodeExecutor<TInput = unknown, TOutput = unknown> = (
   input: TInput,
-  context: NodeExecutionContext
-) => Promise<NodeExecutionResult<TOutput>>;
+  context: NodeExecutionContext,
+) => Promise<NodeExecutionResult<TOutput>>
 
 /**
  * Node capabilities for UI and runtime behavior.
  */
 export interface NodeCapabilities {
   /** Node supports data enrichment */
-  supportsEnrichment?: boolean;
+  supportsEnrichment?: boolean
   /** Node supports bulk actions */
-  supportsBulkActions?: boolean;
+  supportsBulkActions?: boolean
   /** Node supports approval workflow */
-  supportsApproval?: boolean;
+  supportsApproval?: boolean
   /** Node can be re-run after completion */
-  supportsRerun?: boolean;
+  supportsRerun?: boolean
   /** Node supports cancellation */
-  supportsCancel?: boolean;
+  supportsCancel?: boolean
 }
 
 /**
  * Node category for organization.
  */
-export type NodeCategory = 'action' | 'logic' | 'integration' | 'transform';
+export type NodeCategory = 'action' | 'logic' | 'integration' | 'transform'
 
 /**
  * Metadata about a node (safe for client-side use).
  */
 export interface NodeMetadata {
   /** Unique node type identifier */
-  type: string;
+  type: string
   /** Display name */
-  name: string;
+  name: string
   /** Description of what the node does */
-  description: string;
+  description: string
   /** Category for grouping */
-  category: NodeCategory;
+  category: NodeCategory
   /** Estimated duration in seconds */
-  estimatedDuration?: number;
+  estimatedDuration?: number
   /** Node capabilities */
-  capabilities?: NodeCapabilities;
+  capabilities?: NodeCapabilities
 }
 
 /**
@@ -164,12 +168,14 @@ export interface NodeMetadata {
  * @template TInput - Input type
  * @template TOutput - Output type
  */
-export interface NodeDefinition<TInput = unknown, TOutput = unknown>
-  extends NodeMetadata {
+export interface NodeDefinition<
+  TInput = unknown,
+  TOutput = unknown,
+> extends NodeMetadata {
   /** Zod schema for validating input */
-  inputSchema: z.ZodSchema<TInput>;
+  inputSchema: z.ZodSchema<TInput>
   /** Zod schema for validating output */
-  outputSchema: z.ZodSchema<TOutput>;
+  outputSchema: z.ZodSchema<TOutput>
   /** Executor function */
-  executor: NodeExecutor<TInput, TOutput>;
+  executor: NodeExecutor<TInput, TOutput>
 }

--- a/packages/nodes/src/index.ts
+++ b/packages/nodes/src/index.ts
@@ -11,7 +11,7 @@ export {
   EndOutputSchema,
   DelayInputSchema,
   DelayOutputSchema,
-} from './logic/index.js';
+} from './logic/index.js'
 
 export type {
   ConditionalInput,
@@ -22,7 +22,7 @@ export type {
   EndOutput,
   DelayInput,
   DelayOutput,
-} from './logic/index.js';
+} from './logic/index.js'
 
 // Transform nodes
 export {
@@ -37,7 +37,7 @@ export {
   SortInputSchema,
   SortOutputSchema,
   SortDirectionSchema,
-} from './transform/index.js';
+} from './transform/index.js'
 
 export type {
   MapInput,
@@ -48,7 +48,7 @@ export type {
   SortInput,
   SortOutput,
   SortDirection,
-} from './transform/index.js';
+} from './transform/index.js'
 
 // Example nodes
 export {
@@ -59,7 +59,7 @@ export {
   breadNode,
   BreadInputSchema,
   BreadOutputSchema,
-} from './examples/index.js';
+} from './examples/index.js'
 
 export type {
   HttpRequestInput,
@@ -67,7 +67,7 @@ export type {
   HttpMethod,
   BreadInput,
   BreadOutput,
-} from './examples/index.js';
+} from './examples/index.js'
 
 // Integration nodes
 export {
@@ -119,7 +119,19 @@ export {
   firecrawlExtractNode,
   FirecrawlExtractInputSchema,
   FirecrawlExtractOutputSchema,
-} from './integrations/index.js';
+  // Dev.to
+  devtoCreateArticleNode,
+  DevtoArticleSchema,
+  DevtoCreateArticleInputSchema,
+  DevtoCreateArticleOutputSchema,
+  devtoUpdateArticleNode,
+  DevtoUpdateArticleInputSchema,
+  DevtoUpdateArticleOutputSchema,
+  devtoGetArticlesNode,
+  DevtoGetArticlesInputSchema,
+  DevtoGetArticlesOutputSchema,
+  devtoCredential,
+} from './integrations/index.js'
 
 export type {
   RedditMonitorInput,
@@ -153,7 +165,14 @@ export type {
   FirecrawlCrawlOutput,
   FirecrawlExtractInput,
   FirecrawlExtractOutput,
-} from './integrations/index.js';
+  DevtoArticle,
+  DevtoCreateArticleInput,
+  DevtoCreateArticleOutput,
+  DevtoUpdateArticleInput,
+  DevtoUpdateArticleOutput,
+  DevtoGetArticlesInput,
+  DevtoGetArticlesOutput,
+} from './integrations/index.js'
 
 // AI nodes
 export {
@@ -168,7 +187,7 @@ export {
   socialAiAnalyzeNode,
   SocialAiAnalyzeInputSchema,
   SocialAiAnalyzeOutputSchema,
-} from './ai/index.js';
+} from './ai/index.js'
 
 export type {
   SocialKeywordGeneratorInput,
@@ -181,14 +200,14 @@ export type {
   SocialAiAnalyzeOutput,
   SocialPost,
   AnalyzedPost,
-} from './ai/index.js';
+} from './ai/index.js'
 
 // All nodes as a collection
-import { conditionalNode } from './logic/index.js';
-import { endNode } from './logic/index.js';
-import { delayNode } from './logic/index.js';
-import { mapNode, filterNode, sortNode } from './transform/index.js';
-import { httpRequestNode, breadNode } from './examples/index.js';
+import { conditionalNode } from './logic/index.js'
+import { endNode } from './logic/index.js'
+import { delayNode } from './logic/index.js'
+import { mapNode, filterNode, sortNode } from './transform/index.js'
+import { httpRequestNode, breadNode } from './examples/index.js'
 import {
   redditMonitorNode,
   twitterMonitorNode,
@@ -203,12 +222,15 @@ import {
   firecrawlScrapeNode,
   firecrawlCrawlNode,
   firecrawlExtractNode,
-} from './integrations/index.js';
+  devtoCreateArticleNode,
+  devtoUpdateArticleNode,
+  devtoGetArticlesNode,
+} from './integrations/index.js'
 import {
   socialKeywordGeneratorNode,
   draftEmailsNode,
   socialAiAnalyzeNode,
-} from './ai/index.js';
+} from './ai/index.js'
 
 /**
  * All built-in nodes as an array for easy registration
@@ -239,8 +261,11 @@ export const builtInNodes = [
   firecrawlScrapeNode,
   firecrawlCrawlNode,
   firecrawlExtractNode,
+  devtoCreateArticleNode,
+  devtoUpdateArticleNode,
+  devtoGetArticlesNode,
   // AI
   socialKeywordGeneratorNode,
   draftEmailsNode,
   socialAiAnalyzeNode,
-];
+]

--- a/packages/nodes/src/integrations/devto/__tests__/devto.test.ts
+++ b/packages/nodes/src/integrations/devto/__tests__/devto.test.ts
@@ -1,0 +1,482 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  devtoCredential,
+  devtoCreateArticleNode,
+  devtoUpdateArticleNode,
+  devtoGetArticlesNode,
+  DevtoCreateArticleInputSchema,
+  DevtoUpdateArticleInputSchema,
+  DevtoGetArticlesInputSchema,
+  DevtoArticleSchema,
+  normalizeDevtoArticle,
+} from '../index.js'
+
+const mockRawArticle = {
+  id: 1,
+  title: 'Hello World',
+  slug: 'hello-world-abc123',
+  url: 'https://dev.to/user/hello-world-abc123',
+  published: true,
+  published_at: '2024-01-01T00:00:00Z',
+  tag_list: ['webdev', 'javascript'],
+  description: 'A hello world post',
+  reading_time_minutes: 2,
+}
+
+const mockContext = {
+  userId: 'u1',
+  workflowExecutionId: 'w1',
+  variables: {},
+  resolveNestedPath: () => undefined,
+  credentials: { devto: { apiKey: 'test-api-key' } },
+} as const
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+// ─── Credential ──────────────────────────────────────────────────────────────
+
+describe('devto credential', () => {
+  it('defines credential metadata', () => {
+    expect(devtoCredential.name).toBe('devto')
+    expect(devtoCredential.type).toBe('apiKey')
+    expect(devtoCredential.authenticate.properties['api-key']).toBe(
+      '{{apiKey}}',
+    )
+  })
+})
+
+// ─── Schema validation ────────────────────────────────────────────────────────
+
+describe('devto schemas', () => {
+  it('DevtoCreateArticleInputSchema accepts input without published (executor applies default)', () => {
+    const result = DevtoCreateArticleInputSchema.safeParse({
+      title: 'A Post',
+      bodyMarkdown: '# Hello',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.published).toBeUndefined()
+  })
+
+  it('DevtoCreateArticleInputSchema rejects missing required fields', () => {
+    const result = DevtoCreateArticleInputSchema.safeParse({ title: 'A Post' })
+    expect(result.success).toBe(false)
+  })
+
+  it('DevtoUpdateArticleInputSchema requires id', () => {
+    const result = DevtoUpdateArticleInputSchema.safeParse({ title: 'Updated' })
+    expect(result.success).toBe(false)
+  })
+
+  it('DevtoUpdateArticleInputSchema allows partial updates', () => {
+    const result = DevtoUpdateArticleInputSchema.safeParse({
+      id: 42,
+      title: 'Updated Title',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('DevtoGetArticlesInputSchema username is optional', () => {
+    const result = DevtoGetArticlesInputSchema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.username).toBeUndefined()
+      expect(result.data.page).toBeUndefined()
+      expect(result.data.perPage).toBeUndefined()
+    }
+  })
+
+  it('DevtoArticleSchema validates normalized article', () => {
+    const result = DevtoArticleSchema.safeParse({
+      id: 1,
+      title: 'Hello',
+      slug: 'hello',
+      url: 'https://dev.to/u/hello',
+      published: true,
+      publishedAt: null,
+      tags: ['js'],
+      description: null,
+      readingTimeMinutes: 1,
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+// ─── normalizeDevtoArticle ────────────────────────────────────────────────────
+
+describe('normalizeDevtoArticle', () => {
+  it('maps snake_case API fields to camelCase', () => {
+    const result = normalizeDevtoArticle(mockRawArticle)
+    expect(result.id).toBe(1)
+    expect(result.title).toBe('Hello World')
+    expect(result.publishedAt).toBe('2024-01-01T00:00:00Z')
+    expect(result.readingTimeMinutes).toBe(2)
+    expect(result.tags).toEqual(['webdev', 'javascript'])
+  })
+
+  it('handles comma-separated string tag_list', () => {
+    const result = normalizeDevtoArticle({
+      ...mockRawArticle,
+      tag_list: 'webdev, javascript',
+    })
+    expect(result.tags).toEqual(['webdev', 'javascript'])
+  })
+
+  it('handles null published_at', () => {
+    const result = normalizeDevtoArticle({
+      ...mockRawArticle,
+      published_at: null,
+    })
+    expect(result.publishedAt).toBeNull()
+  })
+
+  it('handles null description', () => {
+    const result = normalizeDevtoArticle({
+      ...mockRawArticle,
+      description: null,
+    })
+    expect(result.description).toBeNull()
+  })
+})
+
+// ─── devto_create_article ─────────────────────────────────────────────────────
+
+describe('devto_create_article', () => {
+  it('fails when API key is missing', async () => {
+    const result = await devtoCreateArticleNode.executor(
+      { title: 'Test', bodyMarkdown: '# Test', published: false },
+      {
+        userId: 'u1',
+        workflowExecutionId: 'w1',
+        variables: {},
+        resolveNestedPath: () => undefined,
+      },
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('devto.apiKey')
+  })
+
+  it('sends correct POST request and returns normalized article', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(mockRawArticle), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await devtoCreateArticleNode.executor(
+      {
+        title: 'Hello World',
+        bodyMarkdown: '# Hello',
+        published: true,
+        tags: ['webdev'],
+      },
+      mockContext,
+    )
+
+    expect(result.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/api/articles')
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>)['api-key']).toBe(
+      'test-api-key',
+    )
+
+    const body = JSON.parse(String(init.body))
+    expect(body.article.title).toBe('Hello World')
+    expect(body.article.body_markdown).toBe('# Hello')
+    expect(body.article.published).toBe(true)
+    expect(body.article.tags).toEqual(['webdev'])
+
+    if (result.success) {
+      expect(result.output?.id).toBe(1)
+      expect(result.output?.title).toBe('Hello World')
+      expect(result.output?.tags).toEqual(['webdev', 'javascript'])
+    }
+  })
+
+  it('passes series and canonicalUrl to the API request body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(mockRawArticle), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await devtoCreateArticleNode.executor(
+      {
+        title: 'Series Post',
+        bodyMarkdown: '# Part 1',
+        series: 'My Tutorial Series',
+        canonicalUrl: 'https://myblog.com/original-post',
+      },
+      mockContext,
+    )
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(String(init.body))
+    expect(body.article.series).toBe('My Tutorial Series')
+    expect(body.article.canonical_url).toBe('https://myblog.com/original-post')
+  })
+
+  it('defaults published to false', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ...mockRawArticle,
+          published: false,
+          published_at: null,
+        }),
+        {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await devtoCreateArticleNode.executor(
+      { title: 'Draft', bodyMarkdown: '# Draft' },
+      mockContext,
+    )
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(String(init.body))
+    expect(body.article.published).toBe(false)
+  })
+
+  it('returns error on non-2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response('Unprocessable Entity', { status: 422 }),
+        ),
+    )
+
+    const result = await devtoCreateArticleNode.executor(
+      { title: 'Bad', bodyMarkdown: '# Bad' },
+      mockContext,
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('422')
+  })
+
+  it('returns error on 401 unauthorized', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('Unauthorized', { status: 401 })),
+    )
+
+    const result = await devtoCreateArticleNode.executor(
+      { title: 'Test', bodyMarkdown: '# Test' },
+      mockContext,
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('401')
+  })
+})
+
+// ─── devto_update_article ─────────────────────────────────────────────────────
+
+describe('devto_update_article', () => {
+  it('fails when API key is missing', async () => {
+    const result = await devtoUpdateArticleNode.executor(
+      { id: 1, title: 'Updated' },
+      {
+        userId: 'u1',
+        workflowExecutionId: 'w1',
+        variables: {},
+        resolveNestedPath: () => undefined,
+      },
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('devto.apiKey')
+  })
+
+  it('sends correct PUT request to articles/:id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ ...mockRawArticle, title: 'Updated Title' }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await devtoUpdateArticleNode.executor(
+      { id: 1, title: 'Updated Title', bodyMarkdown: '# Updated' },
+      mockContext,
+    )
+
+    expect(result.success).toBe(true)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/api/articles/1')
+    expect(init.method).toBe('PUT')
+    expect((init.headers as Record<string, string>)['api-key']).toBe(
+      'test-api-key',
+    )
+
+    const body = JSON.parse(String(init.body))
+    expect(body.article.title).toBe('Updated Title')
+    expect(body.article.body_markdown).toBe('# Updated')
+
+    if (result.success) {
+      expect(result.output?.title).toBe('Updated Title')
+    }
+  })
+
+  it('only sends defined fields in partial update', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(mockRawArticle), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await devtoUpdateArticleNode.executor(
+      { id: 1, published: true },
+      mockContext,
+    )
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(String(init.body))
+    expect(body.article).toEqual({ published: true })
+  })
+
+  it('returns error on non-2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('Not Found', { status: 404 })),
+    )
+
+    const result = await devtoUpdateArticleNode.executor(
+      { id: 999 },
+      mockContext,
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('404')
+  })
+})
+
+// ─── devto_get_articles ────────────────────────────────────────────────────────
+
+describe('devto_get_articles', () => {
+  it('fails when API key is missing', async () => {
+    const result = await devtoGetArticlesNode.executor(
+      {},
+      {
+        userId: 'u1',
+        workflowExecutionId: 'w1',
+        variables: {},
+        resolveNestedPath: () => undefined,
+      },
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('devto.apiKey')
+  })
+
+  it('calls /articles/me when username is not provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([mockRawArticle]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await devtoGetArticlesNode.executor({}, mockContext)
+
+    expect(result.success).toBe(true)
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toContain('/articles/me')
+    expect(url).toContain('page=1')
+    expect(url).toContain('per_page=30')
+  })
+
+  it('calls /articles?username=... when username is provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([mockRawArticle]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await devtoGetArticlesNode.executor(
+      { username: 'johndoe' },
+      mockContext,
+    )
+
+    expect(result.success).toBe(true)
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toContain('/articles?')
+    expect(url).toContain('username=johndoe')
+    expect(url).not.toContain('/articles/me')
+  })
+
+  it('returns normalized articles with count, page, perPage', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([mockRawArticle, mockRawArticle]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await devtoGetArticlesNode.executor(
+      { page: 2, perPage: 10 },
+      mockContext,
+    )
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.output?.count).toBe(2)
+      expect(result.output?.page).toBe(2)
+      expect(result.output?.perPage).toBe(10)
+      expect(result.output?.articles).toHaveLength(2)
+      expect(result.output?.articles[0]?.id).toBe(1)
+    }
+  })
+
+  it('passes pagination query params', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await devtoGetArticlesNode.executor({ page: 3, perPage: 50 }, mockContext)
+
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(url).toContain('page=3')
+    expect(url).toContain('per_page=50')
+  })
+
+  it('returns error on non-2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('Unauthorized', { status: 401 })),
+    )
+
+    const result = await devtoGetArticlesNode.executor({}, mockContext)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('401')
+  })
+})

--- a/packages/nodes/src/integrations/devto/credentials.ts
+++ b/packages/nodes/src/integrations/devto/credentials.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import { defineApiKeyCredential } from '@jam-nodes/core'
+
+export const devtoCredential = defineApiKeyCredential({
+  name: 'devto',
+  displayName: 'Dev.to API Key',
+  documentationUrl: 'https://developers.forem.com/api#section/Authentication',
+  schema: z.object({
+    apiKey: z.string(),
+  }),
+  authenticate: {
+    type: 'header',
+    properties: {
+      'api-key': '{{apiKey}}',
+    },
+  },
+})

--- a/packages/nodes/src/integrations/devto/get-articles.ts
+++ b/packages/nodes/src/integrations/devto/get-articles.ts
@@ -1,0 +1,95 @@
+import { defineNode } from '@jam-nodes/core'
+import { fetchWithRetry } from '../../utils/http.js'
+import {
+  DevtoGetArticlesInputSchema,
+  DevtoGetArticlesOutputSchema,
+  type DevtoGetArticlesInput,
+  type DevtoApiArticle,
+  normalizeDevtoArticle,
+} from './schemas.js'
+
+const DEVTO_API_BASE = 'https://dev.to/api'
+
+export const devtoGetArticlesNode = defineNode({
+  type: 'devto_get_articles',
+  name: 'Dev.to Get Articles',
+  description:
+    "Retrieve articles from Dev.to. If username is omitted, returns the authenticated user's articles.",
+  category: 'integration',
+  inputSchema: DevtoGetArticlesInputSchema,
+  outputSchema: DevtoGetArticlesOutputSchema,
+  estimatedDuration: 5,
+  capabilities: {
+    supportsRerun: true,
+  },
+  executor: async (input: DevtoGetArticlesInput, context) => {
+    try {
+      const apiKey = context.credentials?.devto?.apiKey
+      if (!apiKey) {
+        return {
+          success: false,
+          error:
+            'Dev.to API key not configured. Please provide context.credentials.devto.apiKey.',
+        }
+      }
+
+      const page = input.page ?? 1
+      const perPage = input.perPage ?? 30
+
+      let url: string
+      if (input.username) {
+        // List articles for a public username
+        const params = new URLSearchParams({
+          username: input.username,
+          page: String(page),
+          per_page: String(perPage),
+        })
+        url = `${DEVTO_API_BASE}/articles?${params.toString()}`
+      } else {
+        // List authenticated user's own articles
+        const params = new URLSearchParams({
+          page: String(page),
+          per_page: String(perPage),
+        })
+        url = `${DEVTO_API_BASE}/articles/me?${params.toString()}`
+      }
+
+      const response = await fetchWithRetry(
+        url,
+        {
+          method: 'GET',
+          headers: {
+            'api-key': apiKey,
+          },
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 },
+      )
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        return {
+          success: false,
+          error: `Dev.to API error ${response.status}: ${errorText}`,
+        }
+      }
+
+      const data = (await response.json()) as DevtoApiArticle[]
+      const articles = data.map(normalizeDevtoArticle)
+
+      return {
+        success: true,
+        output: {
+          articles,
+          page,
+          perPage,
+          count: articles.length,
+        },
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }
+    }
+  },
+})

--- a/packages/nodes/src/integrations/devto/index.ts
+++ b/packages/nodes/src/integrations/devto/index.ts
@@ -1,0 +1,25 @@
+export { devtoCreateArticleNode } from './create-article.js'
+
+export { devtoUpdateArticleNode } from './update-article.js'
+
+export { devtoGetArticlesNode } from './get-articles.js'
+
+export {
+  DevtoArticleSchema,
+  DevtoCreateArticleInputSchema,
+  DevtoCreateArticleOutputSchema,
+  DevtoUpdateArticleInputSchema,
+  DevtoUpdateArticleOutputSchema,
+  DevtoGetArticlesInputSchema,
+  DevtoGetArticlesOutputSchema,
+  normalizeDevtoArticle,
+  type DevtoArticle,
+  type DevtoCreateArticleInput,
+  type DevtoCreateArticleOutput,
+  type DevtoUpdateArticleInput,
+  type DevtoUpdateArticleOutput,
+  type DevtoGetArticlesInput,
+  type DevtoGetArticlesOutput,
+} from './schemas.js'
+
+export { devtoCredential } from './credentials.js'

--- a/packages/nodes/src/integrations/devto/schemas.ts
+++ b/packages/nodes/src/integrations/devto/schemas.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod'
+
+// Normalized article shape shared across create/update/get
+export const DevtoArticleSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  slug: z.string(),
+  url: z.string(),
+  published: z.boolean(),
+  publishedAt: z.string().nullable(),
+  tags: z.array(z.string()),
+  description: z.string().nullable(),
+  readingTimeMinutes: z.number(),
+})
+
+// Input schemas
+
+export const DevtoCreateArticleInputSchema = z.object({
+  title: z.string().min(1),
+  bodyMarkdown: z.string().min(1),
+  published: z.boolean().optional(),
+  tags: z.array(z.string()).optional(),
+  series: z.string().optional(),
+  canonicalUrl: z.string().url().optional(),
+  description: z.string().optional(),
+})
+
+export const DevtoUpdateArticleInputSchema = z.object({
+  id: z.number().int().positive(),
+  title: z.string().min(1).optional(),
+  bodyMarkdown: z.string().min(1).optional(),
+  published: z.boolean().optional(),
+  tags: z.array(z.string()).optional(),
+  description: z.string().optional(),
+})
+
+export const DevtoGetArticlesInputSchema = z.object({
+  username: z.string().optional(),
+  page: z.number().int().positive().optional(),
+  perPage: z.number().int().positive().max(1000).optional(),
+})
+
+// Output schemas
+
+export const DevtoCreateArticleOutputSchema = DevtoArticleSchema
+
+export const DevtoUpdateArticleOutputSchema = DevtoArticleSchema
+
+export const DevtoGetArticlesOutputSchema = z.object({
+  articles: z.array(DevtoArticleSchema),
+  page: z.number(),
+  perPage: z.number(),
+  count: z.number(),
+})
+
+// Raw API response shape (internal use only)
+export interface DevtoApiArticle {
+  id: number
+  title: string
+  slug: string
+  url: string
+  published: boolean
+  published_at: string | null
+  tag_list: string[] | string
+  description: string | null
+  reading_time_minutes: number
+}
+
+/**
+ * Normalize a raw Dev.to API article response into the minimal output shape.
+ */
+export function normalizeDevtoArticle(raw: DevtoApiArticle): DevtoArticle {
+  return {
+    id: raw.id,
+    title: raw.title,
+    slug: raw.slug,
+    url: raw.url,
+    published: raw.published,
+    publishedAt: raw.published_at ?? null,
+    tags: Array.isArray(raw.tag_list)
+      ? raw.tag_list
+      : raw.tag_list
+        ? raw.tag_list
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean)
+        : [],
+    description: raw.description ?? null,
+    readingTimeMinutes: raw.reading_time_minutes ?? 0,
+  }
+}
+
+// Type exports
+export type DevtoArticle = z.infer<typeof DevtoArticleSchema>
+export type DevtoCreateArticleInput = z.infer<
+  typeof DevtoCreateArticleInputSchema
+>
+export type DevtoCreateArticleOutput = z.infer<
+  typeof DevtoCreateArticleOutputSchema
+>
+export type DevtoUpdateArticleInput = z.infer<
+  typeof DevtoUpdateArticleInputSchema
+>
+export type DevtoUpdateArticleOutput = z.infer<
+  typeof DevtoUpdateArticleOutputSchema
+>
+export type DevtoGetArticlesInput = z.infer<typeof DevtoGetArticlesInputSchema>
+export type DevtoGetArticlesOutput = z.infer<
+  typeof DevtoGetArticlesOutputSchema
+>

--- a/packages/nodes/src/integrations/devto/update-article.ts
+++ b/packages/nodes/src/integrations/devto/update-article.ts
@@ -1,0 +1,79 @@
+import { defineNode } from '@jam-nodes/core'
+import { fetchWithRetry } from '../../utils/http.js'
+import {
+  DevtoUpdateArticleInputSchema,
+  DevtoUpdateArticleOutputSchema,
+  type DevtoUpdateArticleInput,
+  type DevtoApiArticle,
+  normalizeDevtoArticle,
+} from './schemas.js'
+
+const DEVTO_API_BASE = 'https://dev.to/api'
+
+export const devtoUpdateArticleNode = defineNode({
+  type: 'devto_update_article',
+  name: 'Dev.to Update Article',
+  description: 'Update an existing article on Dev.to by its ID',
+  category: 'integration',
+  inputSchema: DevtoUpdateArticleInputSchema,
+  outputSchema: DevtoUpdateArticleOutputSchema,
+  estimatedDuration: 5,
+  capabilities: {
+    supportsRerun: true,
+  },
+  executor: async (input: DevtoUpdateArticleInput, context) => {
+    try {
+      const apiKey = context.credentials?.devto?.apiKey
+      if (!apiKey) {
+        return {
+          success: false,
+          error:
+            'Dev.to API key not configured. Please provide context.credentials.devto.apiKey.',
+        }
+      }
+
+      const articleBody: Record<string, unknown> = {}
+      if (input.title !== undefined) articleBody['title'] = input.title
+      if (input.bodyMarkdown !== undefined)
+        articleBody['body_markdown'] = input.bodyMarkdown
+      if (input.published !== undefined)
+        articleBody['published'] = input.published
+      if (input.tags !== undefined) articleBody['tags'] = input.tags
+      if (input.description !== undefined)
+        articleBody['description'] = input.description
+
+      const response = await fetchWithRetry(
+        `${DEVTO_API_BASE}/articles/${input.id}`,
+        {
+          method: 'PUT',
+          headers: {
+            'api-key': apiKey,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ article: articleBody }),
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 },
+      )
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        return {
+          success: false,
+          error: `Dev.to API error ${response.status}: ${errorText}`,
+        }
+      }
+
+      const data = (await response.json()) as DevtoApiArticle
+
+      return {
+        success: true,
+        output: normalizeDevtoArticle(data),
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }
+    }
+  },
+})

--- a/packages/nodes/src/integrations/index.ts
+++ b/packages/nodes/src/integrations/index.ts
@@ -18,7 +18,7 @@ export {
   type LinkedInMonitorInput,
   type LinkedInMonitorOutput,
   type LinkedInPost,
-} from './social/index.js';
+} from './social/index.js'
 
 // OpenAI integrations
 export {
@@ -27,7 +27,7 @@ export {
   SoraVideoOutputSchema,
   type SoraVideoInput,
   type SoraVideoOutput,
-} from './openai/index.js';
+} from './openai/index.js'
 
 // DataForSEO integrations
 export {
@@ -42,7 +42,7 @@ export {
   type SeoAuditInput,
   type SeoAuditOutput,
   type SeoIssue,
-} from './dataforseo/index.js';
+} from './dataforseo/index.js'
 
 // Apollo integrations
 export {
@@ -51,7 +51,7 @@ export {
   SearchContactsOutputSchema,
   type SearchContactsInput,
   type SearchContactsOutput,
-} from './apollo/index.js';
+} from './apollo/index.js'
 
 // Discord integrations
 export {
@@ -74,7 +74,7 @@ export {
   type DiscordEmbed,
   discordBotCredential,
   discordWebhookCredential,
-} from './discord/index.js';
+} from './discord/index.js'
 
 // Firecrawl integrations
 export {
@@ -93,4 +93,27 @@ export {
   FirecrawlExtractOutputSchema,
   type FirecrawlExtractInput,
   type FirecrawlExtractOutput,
-} from './firecrawl/index.js';
+} from './firecrawl/index.js'
+
+// Dev.to integrations
+export {
+  devtoCreateArticleNode,
+  devtoUpdateArticleNode,
+  devtoGetArticlesNode,
+  DevtoArticleSchema,
+  DevtoCreateArticleInputSchema,
+  DevtoCreateArticleOutputSchema,
+  DevtoUpdateArticleInputSchema,
+  DevtoUpdateArticleOutputSchema,
+  DevtoGetArticlesInputSchema,
+  DevtoGetArticlesOutputSchema,
+  normalizeDevtoArticle,
+  devtoCredential,
+  type DevtoArticle,
+  type DevtoCreateArticleInput,
+  type DevtoCreateArticleOutput,
+  type DevtoUpdateArticleInput,
+  type DevtoUpdateArticleOutput,
+  type DevtoGetArticlesInput,
+  type DevtoGetArticlesOutput,
+} from './devto/index.js'

--- a/packages/playground/src/commands/run.ts
+++ b/packages/playground/src/commands/run.ts
@@ -1,144 +1,261 @@
-import { Command } from 'commander';
-import chalk from 'chalk';
-import ora from 'ora';
-import dotenv from 'dotenv';
-import { createRegistry, type NodeExecutionContext, type NodeCredentials } from '@jam-nodes/core';
+import { Command } from 'commander'
+import chalk from 'chalk'
+import ora from 'ora'
+import dotenv from 'dotenv'
+import {
+  createRegistry,
+  type NodeExecutionContext,
+  type NodeCredentials,
+} from '@jam-nodes/core'
 
 // Load environment variables from .env file
-dotenv.config();
-import { builtInNodes } from '@jam-nodes/nodes';
+dotenv.config()
+import { builtInNodes } from '@jam-nodes/nodes'
 import {
   getCredentials,
   saveCredentials,
   getCredentialSource,
-} from '../credentials/index.js';
+} from '../credentials/index.js'
 import {
   promptForNodeInput,
   promptForCredentials,
   promptSaveCredentials,
   selectNode,
-} from '../ui/index.js';
-import { generateMockOutput } from '../utils/index.js';
+} from '../ui/index.js'
+import { generateMockOutput } from '../utils/index.js'
 
 // Create and populate the registry
-const registry = createRegistry();
+const registry = createRegistry()
 for (const node of builtInNodes) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  registry.register(node as any);
+  registry.register(node as any)
 }
 
 /**
  * Credential requirements for each node type
  */
-const NODE_CREDENTIAL_REQUIREMENTS: Record<string, { service: string; fields: { name: string; envVar: string }[] }[]> = {
-  search_contacts: [{ service: 'apollo', fields: [{ name: 'apiKey', envVar: 'APOLLO_API_KEY' }] }],
+const NODE_CREDENTIAL_REQUIREMENTS: Record<
+  string,
+  { service: string; fields: { name: string; envVar: string }[] }[]
+> = {
+  search_contacts: [
+    {
+      service: 'apollo',
+      fields: [{ name: 'apiKey', envVar: 'APOLLO_API_KEY' }],
+    },
+  ],
   reddit_monitor: [], // No credentials required - uses public API
-  twitter_monitor: [{ service: 'twitter', fields: [{ name: 'twitterApiIoKey', envVar: 'TWITTERAPI_IO_KEY' }] }],
-  linkedin_monitor: [{ service: 'forumScout', fields: [{ name: 'apiKey', envVar: 'FORUMSCOUT_API_KEY' }] }],
-  sora_video: [{ service: 'openai', fields: [{ name: 'apiKey', envVar: 'OPENAI_API_KEY' }] }],
-  seo_keyword_research: [{ service: 'dataForSeo', fields: [{ name: 'apiToken', envVar: 'DATAFORSEO_API_TOKEN' }] }],
-  seo_audit: [{ service: 'dataForSeo', fields: [{ name: 'apiToken', envVar: 'DATAFORSEO_API_TOKEN' }] }],
-  social_keyword_generator: [{ service: 'anthropic', fields: [{ name: 'apiKey', envVar: 'ANTHROPIC_API_KEY' }] }],
-  draft_emails: [{ service: 'anthropic', fields: [{ name: 'apiKey', envVar: 'ANTHROPIC_API_KEY' }] }],
-  social_ai_analyze: [{ service: 'anthropic', fields: [{ name: 'apiKey', envVar: 'ANTHROPIC_API_KEY' }] }],
-  discord_send_message: [{ service: 'discordBot', fields: [{ name: 'botToken', envVar: 'DISCORD_BOT_TOKEN' }] }],
-  discord_send_webhook: [{ service: 'discordWebhook', fields: [{ name: 'webhookUrl', envVar: 'DISCORD_WEBHOOK_URL' }] }],
-  discord_create_thread: [{ service: 'discordBot', fields: [{ name: 'botToken', envVar: 'DISCORD_BOT_TOKEN' }] }],
-};
+  twitter_monitor: [
+    {
+      service: 'twitter',
+      fields: [{ name: 'twitterApiIoKey', envVar: 'TWITTERAPI_IO_KEY' }],
+    },
+  ],
+  linkedin_monitor: [
+    {
+      service: 'forumScout',
+      fields: [{ name: 'apiKey', envVar: 'FORUMSCOUT_API_KEY' }],
+    },
+  ],
+  sora_video: [
+    {
+      service: 'openai',
+      fields: [{ name: 'apiKey', envVar: 'OPENAI_API_KEY' }],
+    },
+  ],
+  seo_keyword_research: [
+    {
+      service: 'dataForSeo',
+      fields: [{ name: 'apiToken', envVar: 'DATAFORSEO_API_TOKEN' }],
+    },
+  ],
+  seo_audit: [
+    {
+      service: 'dataForSeo',
+      fields: [{ name: 'apiToken', envVar: 'DATAFORSEO_API_TOKEN' }],
+    },
+  ],
+  social_keyword_generator: [
+    {
+      service: 'anthropic',
+      fields: [{ name: 'apiKey', envVar: 'ANTHROPIC_API_KEY' }],
+    },
+  ],
+  draft_emails: [
+    {
+      service: 'anthropic',
+      fields: [{ name: 'apiKey', envVar: 'ANTHROPIC_API_KEY' }],
+    },
+  ],
+  social_ai_analyze: [
+    {
+      service: 'anthropic',
+      fields: [{ name: 'apiKey', envVar: 'ANTHROPIC_API_KEY' }],
+    },
+  ],
+  discord_send_message: [
+    {
+      service: 'discordBot',
+      fields: [{ name: 'botToken', envVar: 'DISCORD_BOT_TOKEN' }],
+    },
+  ],
+  discord_send_webhook: [
+    {
+      service: 'discordWebhook',
+      fields: [{ name: 'webhookUrl', envVar: 'DISCORD_WEBHOOK_URL' }],
+    },
+  ],
+  discord_create_thread: [
+    {
+      service: 'discordBot',
+      fields: [{ name: 'botToken', envVar: 'DISCORD_BOT_TOKEN' }],
+    },
+  ],
+  devto_create_article: [
+    { service: 'devto', fields: [{ name: 'apiKey', envVar: 'DEVTO_API_KEY' }] },
+  ],
+  devto_update_article: [
+    { service: 'devto', fields: [{ name: 'apiKey', envVar: 'DEVTO_API_KEY' }] },
+  ],
+  devto_get_articles: [
+    { service: 'devto', fields: [{ name: 'apiKey', envVar: 'DEVTO_API_KEY' }] },
+  ],
+}
 
 /**
  * Run command - executes a node with input
  */
 export const runCommand = new Command('run')
   .description('Run a jam-node interactively')
-  .argument('[node-type]', 'Node type to run (interactive selection if omitted)')
+  .argument(
+    '[node-type]',
+    'Node type to run (interactive selection if omitted)',
+  )
   .option('-i, --input <json>', 'Input as JSON string')
-  .option('-m, --mock', 'Use mock mode (returns sample data without calling APIs)')
+  .option(
+    '-m, --mock',
+    'Use mock mode (returns sample data without calling APIs)',
+  )
   .option('--no-confirm', 'Skip confirmation prompt')
   .action(async (nodeType: string | undefined, options) => {
     try {
       // If no node type specified, show selection
       if (!nodeType) {
-        const nodes = registry.getAllMetadata();
-        nodeType = await selectNode(nodes);
+        const nodes = registry.getAllMetadata()
+        nodeType = await selectNode(nodes)
       }
 
       // Get node definition
-      const definition = registry.getDefinition(nodeType);
+      const definition = registry.getDefinition(nodeType)
       if (!definition) {
-        console.error(chalk.red(`Unknown node type: ${nodeType}`));
-        console.log(chalk.dim('Use "jam list" to see available nodes'));
-        process.exit(1);
+        console.error(chalk.red(`Unknown node type: ${nodeType}`))
+        console.log(chalk.dim('Use "jam list" to see available nodes'))
+        process.exit(1)
       }
 
       // Display node info
-      console.log();
-      console.log(chalk.bold.cyan('┌─────────────────────────────────────────────────────────────┐'));
-      console.log(chalk.bold.cyan('│  ') + chalk.bold(definition.name).padEnd(57) + chalk.bold.cyan('│'));
-      console.log(chalk.bold.cyan('│  ') + chalk.dim(definition.description.slice(0, 55)).padEnd(57) + chalk.bold.cyan('│'));
-      console.log(chalk.bold.cyan('└─────────────────────────────────────────────────────────────┘'));
+      console.log()
+      console.log(
+        chalk.bold.cyan(
+          '┌─────────────────────────────────────────────────────────────┐',
+        ),
+      )
+      console.log(
+        chalk.bold.cyan('│  ') +
+          chalk.bold(definition.name).padEnd(57) +
+          chalk.bold.cyan('│'),
+      )
+      console.log(
+        chalk.bold.cyan('│  ') +
+          chalk.dim(definition.description.slice(0, 55)).padEnd(57) +
+          chalk.bold.cyan('│'),
+      )
+      console.log(
+        chalk.bold.cyan(
+          '└─────────────────────────────────────────────────────────────┘',
+        ),
+      )
 
       // Mock mode notice
       if (options.mock) {
-        console.log();
-        console.log(chalk.yellow('⚡ Mock mode enabled - returning sample data without API calls'));
+        console.log()
+        console.log(
+          chalk.yellow(
+            '⚡ Mock mode enabled - returning sample data without API calls',
+          ),
+        )
       }
 
       // Check for required credentials
-      const credentialRequirements = NODE_CREDENTIAL_REQUIREMENTS[nodeType] || [];
-      const nodeCredentials: NodeCredentials = {};
+      const credentialRequirements =
+        NODE_CREDENTIAL_REQUIREMENTS[nodeType] || []
+      const nodeCredentials: NodeCredentials = {}
 
       if (credentialRequirements.length > 0 && !options.mock) {
-        console.log();
-        const serviceNames = credentialRequirements.map(r => r.service).join(', ');
-        console.log(chalk.dim(`This node requires: ${serviceNames}`));
+        console.log()
+        const serviceNames = credentialRequirements
+          .map((r) => r.service)
+          .join(', ')
+        console.log(chalk.dim(`This node requires: ${serviceNames}`))
 
         for (const requirement of credentialRequirements) {
-          const { service, fields } = requirement;
-          const source = await getCredentialSource(service);
+          const { service, fields } = requirement
+          const source = await getCredentialSource(service)
 
           if (source) {
-            console.log(chalk.green(`✓ ${service} credentials found (${source})`));
-            const creds = await getCredentials(service);
+            console.log(
+              chalk.green(`✓ ${service} credentials found (${source})`),
+            )
+            const creds = await getCredentials(service)
             if (creds) {
               // Map stored credentials to NodeCredentials format
-              (nodeCredentials as Record<string, Record<string, string>>)[service] = creds;
+              ;(nodeCredentials as Record<string, Record<string, string>>)[
+                service
+              ] = creds
             }
           } else {
             // Check environment variables first
-            let foundInEnv = true;
-            const envCreds: Record<string, string> = {};
+            let foundInEnv = true
+            const envCreds: Record<string, string> = {}
 
             for (const field of fields) {
-              const envValue = process.env[field.envVar];
+              const envValue = process.env[field.envVar]
               if (envValue) {
-                envCreds[field.name] = envValue;
-                console.log(chalk.green(`✓ ${service}.${field.name} found in env (${field.envVar})`));
+                envCreds[field.name] = envValue
+                console.log(
+                  chalk.green(
+                    `✓ ${service}.${field.name} found in env (${field.envVar})`,
+                  ),
+                )
               } else {
-                foundInEnv = false;
+                foundInEnv = false
               }
             }
 
             if (foundInEnv) {
-              (nodeCredentials as Record<string, Record<string, string>>)[service] = envCreds;
+              ;(nodeCredentials as Record<string, Record<string, string>>)[
+                service
+              ] = envCreds
             } else {
-              console.log(chalk.yellow(`⚠ ${service} credentials not found`));
+              console.log(chalk.yellow(`⚠ ${service} credentials not found`))
 
               // Prompt for credentials
-              const promptFields = fields.map(f => ({
+              const promptFields = fields.map((f) => ({
                 name: f.name,
                 message: `${service} ${f.name} (or set ${f.envVar}):`,
                 type: 'password' as const,
-              }));
-              const creds = await promptForCredentials(service, promptFields);
+              }))
+              const creds = await promptForCredentials(service, promptFields)
 
-              (nodeCredentials as Record<string, Record<string, string>>)[service] = creds;
+              ;(nodeCredentials as Record<string, Record<string, string>>)[
+                service
+              ] = creds
 
               // Ask if they want to save
-              const shouldSave = await promptSaveCredentials();
+              const shouldSave = await promptSaveCredentials()
               if (shouldSave) {
-                saveCredentials(service, creds);
-                console.log(chalk.green(`✓ ${service} credentials saved`));
+                saveCredentials(service, creds)
+                console.log(chalk.green(`✓ ${service} credentials saved`))
               }
             }
           }
@@ -146,41 +263,41 @@ export const runCommand = new Command('run')
       }
 
       // Get input
-      let input: Record<string, unknown>;
+      let input: Record<string, unknown>
 
       if (options.input) {
         try {
-          input = JSON.parse(options.input);
+          input = JSON.parse(options.input)
         } catch {
-          console.error(chalk.red('Invalid JSON input'));
-          process.exit(1);
+          console.error(chalk.red('Invalid JSON input'))
+          process.exit(1)
         }
       } else {
         // Interactive input
-        input = await promptForNodeInput(definition.inputSchema);
+        input = await promptForNodeInput(definition.inputSchema)
       }
 
       // Display input summary
-      console.log();
-      console.log(chalk.dim('Input:'));
-      console.log(chalk.dim(JSON.stringify(input, null, 2)));
+      console.log()
+      console.log(chalk.dim('Input:'))
+      console.log(chalk.dim(JSON.stringify(input, null, 2)))
 
       // Execute node
       const spinner = ora({
         text: `Executing ${definition.name}...`,
         color: 'cyan',
-      }).start();
+      }).start()
 
       try {
-        let result;
+        let result
 
         if (options.mock) {
           // Mock mode - generate sample output
-          await new Promise((resolve) => setTimeout(resolve, 500)); // Simulate delay
+          await new Promise((resolve) => setTimeout(resolve, 500)) // Simulate delay
           result = {
             success: true,
             output: generateMockOutput(nodeType, definition.outputSchema),
-          };
+          }
         } else {
           // Create execution context with credentials (not services)
           const context: NodeExecutionContext = {
@@ -189,66 +306,70 @@ export const runCommand = new Command('run')
             variables: {},
             resolveNestedPath: (path: string) => {
               // Simple implementation - look in variables
-              const parts = path.split('.');
-              let current: unknown = context.variables;
+              const parts = path.split('.')
+              let current: unknown = context.variables
               for (const part of parts) {
                 if (current && typeof current === 'object') {
-                  current = (current as Record<string, unknown>)[part];
+                  current = (current as Record<string, unknown>)[part]
                 } else {
-                  return undefined;
+                  return undefined
                 }
               }
-              return current;
+              return current
             },
             credentials: nodeCredentials,
-          };
+          }
 
           // Validate input
-          const validatedInput = definition.inputSchema.parse(input);
+          const validatedInput = definition.inputSchema.parse(input)
 
           // Execute
-          result = await definition.executor(validatedInput, context);
+          result = await definition.executor(validatedInput, context)
         }
 
-        spinner.stop();
+        spinner.stop()
 
         // Display result
-        console.log();
+        console.log()
         if (result.success) {
-          console.log(chalk.green.bold('✓ Success!'));
-          console.log();
-          console.log(chalk.dim('Output:'));
-          console.log(formatJson(result.output));
+          console.log(chalk.green.bold('✓ Success!'))
+          console.log()
+          console.log(chalk.dim('Output:'))
+          console.log(formatJson(result.output))
         } else {
-          console.log(chalk.red.bold('✗ Failed'));
-          console.log(chalk.red(result.error || 'Unknown error'));
+          console.log(chalk.red.bold('✗ Failed'))
+          console.log(chalk.red(result.error || 'Unknown error'))
         }
       } catch (error) {
-        spinner.stop();
-        console.log();
-        console.log(chalk.red.bold('✗ Execution failed'));
-        console.log(chalk.red(error instanceof Error ? error.message : 'Unknown error'));
+        spinner.stop()
+        console.log()
+        console.log(chalk.red.bold('✗ Execution failed'))
+        console.log(
+          chalk.red(error instanceof Error ? error.message : 'Unknown error'),
+        )
 
         if (error instanceof Error && error.stack) {
-          console.log(chalk.dim(error.stack));
+          console.log(chalk.dim(error.stack))
         }
       }
     } catch (error) {
-      console.error(chalk.red('Error:'), error instanceof Error ? error.message : error);
-      process.exit(1);
+      console.error(
+        chalk.red('Error:'),
+        error instanceof Error ? error.message : error,
+      )
+      process.exit(1)
     }
-  });
+  })
 
 /**
  * Format JSON with syntax highlighting
  */
 function formatJson(data: unknown): string {
-  const json = JSON.stringify(data, null, 2);
+  const json = JSON.stringify(data, null, 2)
   return json
     .replace(/"([^"]+)":/g, chalk.cyan('"$1":'))
     .replace(/: "([^"]+)"/g, ': ' + chalk.green('"$1"'))
     .replace(/: (\d+)/g, ': ' + chalk.yellow('$1'))
     .replace(/: (true|false)/g, ': ' + chalk.magenta('$1'))
-    .replace(/: (null)/g, ': ' + chalk.dim('$1'));
+    .replace(/: (null)/g, ': ' + chalk.dim('$1'))
 }
-


### PR DESCRIPTION
## Summary

Implements the Dev.to integration requested in #34.

- 3 new nodes: `devtoCreateArticle`, `devtoUpdateArticle`, `devtoGetArticles`
- API key credential (`devto`) with `api-key` header auth
- Normalized article output shape (camelCase, flattened) consistent across all 3 nodes
- `devtoGetArticles` falls back to `/articles/me` (authenticated user) when `username` is omitted
- `published` defaults to `false` to prevent accidental publishing
- Full Markdown support via `bodyMarkdown`; `series` and `canonicalUrl` also supported on create
- Pagination via `page` / `perPage` query params
- All HTTP calls use `fetchWithRetry`

## Test plan

- [x] `npm run build --workspace=packages/nodes` — clean build
- [x] `npm run test --workspace=packages/nodes` — 35 tests pass (27 Dev.to + 8 Discord)
- [x] `pnpm test` — 27 built-in nodes registered including all 3 devto nodes
- [x] `devto_create_article` tested via playground CLI — draft created successfully
- [x] `devto_get_articles` tested via playground CLI — returns authenticated user's articles
- [x] `devto_update_article` tested via playground CLI — article updated/published

Closes #34