### PR TITLE
Add pnpm-workspace.yaml for proper pnpm monorepo support

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - packages/*
+
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
This PR adds pnpm-workspace.yaml to properly configure the monorepo when using pnpm