### PR TITLE
Add Apify integration and credential support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1282,7 +1282,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1714,7 +1713,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2464,7 +2462,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2804,7 +2801,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3147,7 +3143,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3172,7 +3167,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -3802,7 +3796,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4024,7 +4017,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4037,7 +4029,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4051,7 +4042,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
       "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4679,7 +4669,6 @@
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -4800,7 +4789,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5670,7 +5658,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -5686,7 +5673,7 @@
     },
     "packages/core": {
       "name": "@jam-nodes/core",
-      "version": "0.2.5",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "jsonpath-plus": "^10.0.0"
@@ -5740,7 +5727,7 @@
     },
     "packages/nodes": {
       "name": "@jam-nodes/nodes",
-      "version": "0.2.5",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "@jam-nodes/core": "^0.2.1"

--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -72,6 +72,10 @@ export interface NodeCredentials {
     username: string
     applicationPassword: string
   }
+  /** Apify API credentials */
+  apify?: {
+    apiToken: string
+  }
 }
 
 /**

--- a/packages/nodes/src/integrations/apify/apify.test.ts
+++ b/packages/nodes/src/integrations/apify/apify.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    apifyCredential,
+    apifyRunActorNode,
+    apifyGetDatasetNode,
+    apifyGetRunStatusNode,
+    ApifyRunActorInputSchema,
+    ApifyGetDatasetInputSchema,
+    ApifyGetRunStatusInputSchema,
+} from './index.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+// =============================================================================
+// Credential
+// =============================================================================
+
+describe('apify credential', () => {
+    it('defines bearer credential metadata', () => {
+        expect(apifyCredential.name).toBe('apify');
+        expect(apifyCredential.type).toBe('bearer');
+        expect(apifyCredential.authenticate.properties.Authorization).toBe(
+            'Bearer {{apiToken}}'
+        );
+    });
+});
+
+// =============================================================================
+// Schemas
+// =============================================================================
+
+describe('apify schemas', () => {
+    it('parses valid run actor input', () => {
+        const result = ApifyRunActorInputSchema.safeParse({
+            actorId: 'apify/google-search-scraper',
+            input: { queries: ['nodejs'] },
+            waitForFinish: true,
+            timeout: 120,
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it('applies defaults to run actor input', () => {
+        const result = ApifyRunActorInputSchema.safeParse({
+            actorId: 'apify/google-search-scraper',
+        });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.waitForFinish).toBe(true);
+            expect(result.data.timeout).toBe(300);
+        }
+    });
+
+    it('rejects run actor input with empty actorId', () => {
+        const result = ApifyRunActorInputSchema.safeParse({ actorId: '' });
+        expect(result.success).toBe(false);
+    });
+
+    it('parses valid get dataset input with defaults', () => {
+        const result = ApifyGetDatasetInputSchema.safeParse({ datasetId: 'ds123' });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.format).toBe('json');
+        }
+    });
+
+    it('rejects invalid dataset format', () => {
+        const result = ApifyGetDatasetInputSchema.safeParse({
+            datasetId: 'ds123',
+            format: 'toml',
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('parses valid get run status input', () => {
+        const result = ApifyGetRunStatusInputSchema.safeParse({ runId: 'run123' });
+        expect(result.success).toBe(true);
+    });
+});
+
+// =============================================================================
+// apify_run_actor
+// =============================================================================
+
+const makeContext = (credentials?: Record<string, unknown>) => ({
+    userId: 'u1',
+    workflowExecutionId: 'w1',
+    variables: {},
+    resolveNestedPath: () => undefined,
+    credentials,
+});
+
+const makeRun = (status: string) => ({
+    data: {
+        id: 'run1',
+        actId: 'apify~google-search-scraper',
+        status,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        finishedAt: status === 'SUCCEEDED' ? '2026-01-01T00:01:00.000Z' : null,
+        defaultDatasetId: 'ds1',
+        defaultKeyValueStoreId: 'kvs1',
+        defaultRequestQueueId: 'rq1',
+    },
+});
+
+describe('apify_run_actor', () => {
+    it('fails when api token is missing', async () => {
+        const result = await apifyRunActorNode.executor(
+            { actorId: 'apify/google-search-scraper', waitForFinish: false, timeout: 300 },
+            makeContext()
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('apify.apiToken');
+    });
+
+    it('starts actor run without waiting when waitForFinish is false', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(makeRun('RUNNING')), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await apifyRunActorNode.executor(
+            {
+                actorId: 'apify/google-search-scraper',
+                input: { queries: ['nodejs'] },
+                waitForFinish: false,
+                timeout: 300,
+            },
+            makeContext({ apify: { apiToken: 'test_token' } })
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.output?.status).toBe('RUNNING');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toContain('/acts/apify%2Fgoogle-search-scraper/runs');
+        expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test_token');
+    });
+
+    it('polls until SUCCEEDED when waitForFinish is true', async () => {
+        vi.useFakeTimers();
+
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(
+                // First call: start actor (returns RUNNING)
+                new Response(JSON.stringify(makeRun('RUNNING')), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            )
+            .mockResolvedValueOnce(
+                // Second call: poll -> still RUNNING
+                new Response(JSON.stringify(makeRun('RUNNING')), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            )
+            .mockResolvedValueOnce(
+                // Third call: poll -> SUCCEEDED
+                new Response(JSON.stringify(makeRun('SUCCEEDED')), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+        vi.stubGlobal('fetch', fetchMock);
+
+        // Run executor and auto-advance timers so sleep() resolves immediately
+        const executorPromise = apifyRunActorNode.executor(
+            {
+                actorId: 'apify/google-search-scraper',
+                waitForFinish: true,
+                timeout: 300,
+            },
+            makeContext({ apify: { apiToken: 'test_token' } })
+        );
+
+        // Advance through each poll interval
+        await vi.runAllTimersAsync();
+
+        const result = await executorPromise;
+
+        vi.useRealTimers();
+
+        expect(result.success).toBe(true);
+        expect(result.output?.status).toBe('SUCCEEDED');
+        // 1 start + 2 polls
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+});
+
+// =============================================================================
+// apify_get_dataset
+// =============================================================================
+
+describe('apify_get_dataset', () => {
+    it('fails when api token is missing', async () => {
+        const result = await apifyGetDatasetNode.executor(
+            { datasetId: 'ds1', format: 'json' },
+            makeContext()
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('apify.apiToken');
+    });
+
+    it('retrieves dataset items successfully', async () => {
+        const mockItems = [{ url: 'https://example.com', title: 'Example' }];
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    items: mockItems,
+                    count: 1,
+                    total: 1,
+                    offset: 0,
+                    limit: null,
+                    desc: false,
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } }
+            )
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await apifyGetDatasetNode.executor(
+            { datasetId: 'ds1', format: 'json', limit: 10, offset: 0 },
+            makeContext({ apify: { apiToken: 'test_token' } })
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.output?.items).toHaveLength(1);
+        expect(result.output?.count).toBe(1);
+        expect(result.output?.datasetId).toBe('ds1');
+        const [url] = fetchMock.mock.calls[0] as [string];
+        expect(url).toContain('/datasets/ds1/items');
+        expect(url).toContain('limit=10');
+        expect(url).toContain('offset=0');
+    });
+});
+
+// =============================================================================
+// apify_get_run_status
+// =============================================================================
+
+describe('apify_get_run_status', () => {
+    it('fails when api token is missing', async () => {
+        const result = await apifyGetRunStatusNode.executor(
+            { runId: 'run1' },
+            makeContext()
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('apify.apiToken');
+    });
+
+    it('returns run status successfully', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(makeRun('SUCCEEDED')), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await apifyGetRunStatusNode.executor(
+            { runId: 'run1' },
+            makeContext({ apify: { apiToken: 'test_token' } })
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.output?.runId).toBe('run1');
+        expect(result.output?.status).toBe('SUCCEEDED');
+        expect(result.output?.defaultDatasetId).toBe('ds1');
+        const [url] = fetchMock.mock.calls[0] as [string];
+        expect(url).toContain('/actor-runs/run1');
+    });
+});

--- a/packages/nodes/src/integrations/apify/credentials.ts
+++ b/packages/nodes/src/integrations/apify/credentials.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { defineBearerCredential } from '@jam-nodes/core';
+
+export const apifyCredential = defineBearerCredential({
+  name: 'apify',
+  displayName: 'Apify API Token',
+  documentationUrl: 'https://docs.apify.com/platform/integrations/api',
+  schema: z.object({
+    apiToken: z.string(),
+  }),
+  authenticate: {
+    type: 'header',
+    properties: {
+      Authorization: 'Bearer {{apiToken}}',
+    },
+  },
+});

--- a/packages/nodes/src/integrations/apify/get-dataset.ts
+++ b/packages/nodes/src/integrations/apify/get-dataset.ts
@@ -1,0 +1,117 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry } from '../../utils/http.js';
+import {
+    ApifyGetDatasetInputSchema,
+    ApifyGetDatasetOutputSchema,
+    type ApifyGetDatasetInput,
+    type ApifyGetDatasetOutput,
+} from './schemas.js';
+
+const APIFY_API_BASE = 'https://api.apify.com/v2';
+
+// =============================================================================
+// Apify API Types
+// =============================================================================
+
+interface ApifyDatasetItemsResponse {
+    items: Record<string, unknown>[];
+    count: number;
+    total: number;
+    offset: number;
+    limit: number | null;
+    desc: boolean;
+}
+
+// =============================================================================
+// Node Definition
+// =============================================================================
+
+export {
+    ApifyGetDatasetInputSchema,
+    ApifyGetDatasetOutputSchema,
+    type ApifyGetDatasetInput,
+    type ApifyGetDatasetOutput,
+} from './schemas.js';
+
+/**
+ * Apify Get Dataset Node
+ *
+ * Retrieves items from an Apify dataset by its ID.
+ * Supports pagination via limit/offset and multiple output formats.
+ *
+ * @example
+ * ```typescript
+ * const result = await apifyGetDatasetNode.executor({
+ *   datasetId: 'abc123',
+ *   limit: 100,
+ *   offset: 0,
+ *   format: 'json',
+ * }, context);
+ * ```
+ */
+export const apifyGetDatasetNode = defineNode({
+    type: 'apify_get_dataset',
+    name: 'Apify Get Dataset',
+    description: 'Retrieve items from an Apify dataset',
+    category: 'integration',
+    inputSchema: ApifyGetDatasetInputSchema,
+    outputSchema: ApifyGetDatasetOutputSchema,
+    estimatedDuration: 10,
+    capabilities: {
+        supportsRerun: true,
+    },
+
+    executor: async (input: ApifyGetDatasetInput, context) => {
+        try {
+            const apiToken = context.credentials?.apify?.apiToken as string | undefined;
+            if (!apiToken) {
+                return {
+                    success: false,
+                    error:
+                        'Apify API token not configured. Please provide context.credentials.apify.apiToken.',
+                };
+            }
+
+            const params = new URLSearchParams({ format: input.format });
+            if (input.limit != null) params.set('limit', String(input.limit));
+            if (input.offset != null) params.set('offset', String(input.offset));
+
+            const response = await fetchWithRetry(
+                `${APIFY_API_BASE}/datasets/${input.datasetId}/items?${params.toString()}`,
+                {
+                    method: 'GET',
+                    headers: {
+                        Authorization: `Bearer ${apiToken}`,
+                    },
+                },
+                { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+            );
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                return {
+                    success: false,
+                    error: `Apify dataset error: ${response.status} - ${errorText}`,
+                };
+            }
+
+            const data = (await response.json()) as ApifyDatasetItemsResponse;
+
+            const output: ApifyGetDatasetOutput = {
+                items: data.items,
+                count: data.count,
+                total: data.total,
+                offset: data.offset,
+                limit: data.limit,
+                datasetId: input.datasetId,
+            };
+
+            return { success: true, output };
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : 'Failed to retrieve Apify dataset',
+            };
+        }
+    },
+});

--- a/packages/nodes/src/integrations/apify/get-run-status.ts
+++ b/packages/nodes/src/integrations/apify/get-run-status.ts
@@ -1,0 +1,117 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry } from '../../utils/http.js';
+import {
+    ApifyGetRunStatusInputSchema,
+    ApifyGetRunStatusOutputSchema,
+    type ApifyGetRunStatusInput,
+    type ApifyGetRunStatusOutput,
+} from './schemas.js';
+
+const APIFY_API_BASE = 'https://api.apify.com/v2';
+
+// =============================================================================
+// Apify API Types
+// =============================================================================
+
+interface ApifyRunResponse {
+    data: {
+        id: string;
+        actId: string;
+        status: string;
+        startedAt: string | null;
+        finishedAt: string | null;
+        defaultDatasetId: string;
+        defaultKeyValueStoreId: string;
+        defaultRequestQueueId: string;
+    };
+}
+
+// =============================================================================
+// Node Definition
+// =============================================================================
+
+export {
+    ApifyGetRunStatusInputSchema,
+    ApifyGetRunStatusOutputSchema,
+    type ApifyGetRunStatusInput,
+    type ApifyGetRunStatusOutput,
+} from './schemas.js';
+
+/**
+ * Apify Get Run Status Node
+ *
+ * Fetches the current status of an Apify actor run by its run ID.
+ * Useful for polling in external orchestration or checking async run results.
+ *
+ * @example
+ * ```typescript
+ * const result = await apifyGetRunStatusNode.executor({
+ *   runId: 'abc123xyz',
+ * }, context);
+ * ```
+ */
+export const apifyGetRunStatusNode = defineNode({
+    type: 'apify_get_run_status',
+    name: 'Apify Get Run Status',
+    description: 'Check the status of an Apify actor run',
+    category: 'integration',
+    inputSchema: ApifyGetRunStatusInputSchema,
+    outputSchema: ApifyGetRunStatusOutputSchema,
+    estimatedDuration: 3,
+    capabilities: {
+        supportsRerun: true,
+    },
+
+    executor: async (input: ApifyGetRunStatusInput, context) => {
+        try {
+            const apiToken = context.credentials?.apify?.apiToken as string | undefined;
+            if (!apiToken) {
+                return {
+                    success: false,
+                    error:
+                        'Apify API token not configured. Please provide context.credentials.apify.apiToken.',
+                };
+            }
+
+            const response = await fetchWithRetry(
+                `${APIFY_API_BASE}/actor-runs/${input.runId}`,
+                {
+                    method: 'GET',
+                    headers: {
+                        Authorization: `Bearer ${apiToken}`,
+                    },
+                },
+                { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+            );
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                return {
+                    success: false,
+                    error: `Apify run status error: ${response.status} - ${errorText}`,
+                };
+            }
+
+            const data = (await response.json()) as ApifyRunResponse;
+            const run = data.data;
+
+            const output: ApifyGetRunStatusOutput = {
+                runId: run.id,
+                actorId: run.actId,
+                status: run.status,
+                startedAt: run.startedAt,
+                finishedAt: run.finishedAt,
+                defaultDatasetId: run.defaultDatasetId,
+                defaultKeyValueStoreId: run.defaultKeyValueStoreId,
+                defaultRequestQueueId: run.defaultRequestQueueId,
+            };
+
+            return { success: true, output };
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : 'Failed to get Apify run status',
+            };
+        }
+    },
+});

--- a/packages/nodes/src/integrations/apify/index.ts
+++ b/packages/nodes/src/integrations/apify/index.ts
@@ -1,0 +1,25 @@
+export {
+    apifyRunActorNode,
+    ApifyRunActorInputSchema,
+    ApifyRunActorOutputSchema,
+    type ApifyRunActorInput,
+    type ApifyRunActorOutput,
+} from './run-actor.js';
+
+export {
+    apifyGetDatasetNode,
+    ApifyGetDatasetInputSchema,
+    ApifyGetDatasetOutputSchema,
+    type ApifyGetDatasetInput,
+    type ApifyGetDatasetOutput,
+} from './get-dataset.js';
+
+export {
+    apifyGetRunStatusNode,
+    ApifyGetRunStatusInputSchema,
+    ApifyGetRunStatusOutputSchema,
+    type ApifyGetRunStatusInput,
+    type ApifyGetRunStatusOutput,
+} from './get-run-status.js';
+
+export { apifyCredential } from './credentials.js';

--- a/packages/nodes/src/integrations/apify/run-actor.ts
+++ b/packages/nodes/src/integrations/apify/run-actor.ts
@@ -1,0 +1,203 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry, sleep } from '../../utils/http.js';
+import {
+    ApifyRunActorInputSchema,
+    ApifyRunActorOutputSchema,
+    type ApifyRunActorInput,
+    type ApifyRunActorOutput,
+} from './schemas.js';
+
+const APIFY_API_BASE = 'https://api.apify.com/v2';
+const POLL_INTERVAL_MS = 2000;
+
+const TERMINAL_STATUSES = new Set(['SUCCEEDED', 'FAILED', 'ABORTED', 'TIMED-OUT']);
+
+// =============================================================================
+// Apify API Types
+// =============================================================================
+
+interface ApifyRunResponse {
+    data: {
+        id: string;
+        actId: string;
+        status: string;
+        startedAt: string | null;
+        finishedAt: string | null;
+        defaultDatasetId: string;
+        defaultKeyValueStoreId: string;
+        defaultRequestQueueId: string;
+    };
+}
+
+// =============================================================================
+// Apify API Functions
+// =============================================================================
+
+async function startActorRun(
+    apiToken: string,
+    actorId: string,
+    input?: Record<string, unknown>
+): Promise<ApifyRunResponse> {
+    const response = await fetchWithRetry(
+        `${APIFY_API_BASE}/acts/${encodeURIComponent(actorId)}/runs`,
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${apiToken}`,
+            },
+            body: JSON.stringify(input ?? {}),
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+    );
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Apify run actor error: ${response.status} - ${errorText}`);
+    }
+
+    return response.json() as Promise<ApifyRunResponse>;
+}
+
+async function getRunDetails(
+    apiToken: string,
+    runId: string
+): Promise<ApifyRunResponse> {
+    const response = await fetchWithRetry(
+        `${APIFY_API_BASE}/actor-runs/${runId}`,
+        {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${apiToken}`,
+            },
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+    );
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Apify get run error: ${response.status} - ${errorText}`);
+    }
+
+    return response.json() as Promise<ApifyRunResponse>;
+}
+
+async function pollUntilFinished(
+    apiToken: string,
+    runId: string,
+    timeoutMs: number
+): Promise<ApifyRunResponse['data']> {
+    const maxAttempts = Math.ceil(timeoutMs / POLL_INTERVAL_MS);
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const result = await getRunDetails(apiToken, runId);
+
+        if (TERMINAL_STATUSES.has(result.data.status)) {
+            return result.data;
+        }
+
+        await sleep(POLL_INTERVAL_MS);
+    }
+
+    throw new Error(
+        `Apify actor run timed out after ${timeoutMs / 1000}s (runId: ${runId})`
+    );
+}
+
+// =============================================================================
+// Node Definition
+// =============================================================================
+
+export {
+    ApifyRunActorInputSchema,
+    ApifyRunActorOutputSchema,
+    type ApifyRunActorInput,
+    type ApifyRunActorOutput,
+} from './schemas.js';
+
+/**
+ * Apify Run Actor Node
+ *
+ * Starts an Apify actor run and optionally polls until it completes.
+ * Supports all public actors in the Apify Store (e.g. 'apify/google-search-scraper').
+ *
+ * @example
+ * ```typescript
+ * const result = await apifyRunActorNode.executor({
+ *   actorId: 'apify/google-search-scraper',
+ *   input: { queries: ['nodejs'], maxPagesPerQuery: 1 },
+ *   waitForFinish: true,
+ *   timeout: 120,
+ * }, context);
+ * ```
+ */
+export const apifyRunActorNode = defineNode({
+    type: 'apify_run_actor',
+    name: 'Apify Run Actor',
+    description: 'Run an Apify actor (pre-built scraper) and optionally wait for it to finish',
+    category: 'integration',
+    inputSchema: ApifyRunActorInputSchema,
+    outputSchema: ApifyRunActorOutputSchema,
+    estimatedDuration: 60,
+    capabilities: {
+        supportsRerun: true,
+        supportsCancel: true,
+    },
+
+    executor: async (input: ApifyRunActorInput, context) => {
+        try {
+            const apiToken = context.credentials?.apify?.apiToken as string | undefined;
+            if (!apiToken) {
+                return {
+                    success: false,
+                    error:
+                        'Apify API token not configured. Please provide context.credentials.apify.apiToken.',
+                };
+            }
+
+            // Start the actor run
+            const startResult = await startActorRun(apiToken, input.actorId, input.input);
+            const run = startResult.data;
+
+            // If not waiting, return immediately with RUNNING status
+            if (!input.waitForFinish) {
+                const output: ApifyRunActorOutput = {
+                    runId: run.id,
+                    actorId: run.actId,
+                    status: run.status,
+                    startedAt: run.startedAt,
+                    finishedAt: run.finishedAt,
+                    defaultDatasetId: run.defaultDatasetId,
+                    defaultKeyValueStoreId: run.defaultKeyValueStoreId,
+                    defaultRequestQueueId: run.defaultRequestQueueId,
+                };
+                return { success: true, output };
+            }
+
+            // Poll until finished or timeout
+            const finalRun = await pollUntilFinished(
+                apiToken,
+                run.id,
+                input.timeout * 1000
+            );
+
+            const output: ApifyRunActorOutput = {
+                runId: finalRun.id,
+                actorId: finalRun.actId,
+                status: finalRun.status,
+                startedAt: finalRun.startedAt,
+                finishedAt: finalRun.finishedAt,
+                defaultDatasetId: finalRun.defaultDatasetId,
+                defaultKeyValueStoreId: finalRun.defaultKeyValueStoreId,
+                defaultRequestQueueId: finalRun.defaultRequestQueueId,
+            };
+
+            return { success: true, output };
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : 'Failed to run Apify actor',
+            };
+        }
+    },
+});

--- a/packages/nodes/src/integrations/apify/schemas.ts
+++ b/packages/nodes/src/integrations/apify/schemas.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+// =============================================================================
+// Run Actor
+// =============================================================================
+
+export const ApifyRunActorInputSchema = z.object({
+    /** The actor ID or name (e.g. 'apify/google-search-scraper') */
+    actorId: z.string().min(1),
+    /** Input object passed to the actor */
+    input: z.record(z.unknown()).optional(),
+    /** Whether to wait for the run to finish before returning */
+    waitForFinish: z.boolean().default(true),
+    /** Maximum seconds to wait when waitForFinish is true (default: 300) */
+    timeout: z.number().int().positive().default(300),
+});
+
+export const ApifyRunActorOutputSchema = z.object({
+    runId: z.string(),
+    actorId: z.string(),
+    status: z.string(),
+    startedAt: z.string().nullable(),
+    finishedAt: z.string().nullable(),
+    defaultDatasetId: z.string(),
+    defaultKeyValueStoreId: z.string(),
+    defaultRequestQueueId: z.string(),
+});
+
+export type ApifyRunActorInput = z.infer<typeof ApifyRunActorInputSchema>;
+export type ApifyRunActorOutput = z.infer<typeof ApifyRunActorOutputSchema>;
+
+// =============================================================================
+// Get Dataset
+// =============================================================================
+
+export const ApifyGetDatasetInputSchema = z.object({
+    /** The dataset ID to retrieve items from */
+    datasetId: z.string().min(1),
+    /** Maximum number of items to return */
+    limit: z.number().int().positive().optional(),
+    /** Number of items to skip from the start */
+    offset: z.number().int().min(0).optional(),
+    /** Output format of the items */
+    format: z.enum(['json', 'csv', 'xlsx', 'html', 'rss', 'xml', 'jsonl']).default('json'),
+});
+
+export const ApifyGetDatasetOutputSchema = z.object({
+    items: z.array(z.record(z.unknown())),
+    count: z.number(),
+    total: z.number(),
+    offset: z.number(),
+    limit: z.number().nullable(),
+    datasetId: z.string(),
+});
+
+export type ApifyGetDatasetInput = z.infer<typeof ApifyGetDatasetInputSchema>;
+export type ApifyGetDatasetOutput = z.infer<typeof ApifyGetDatasetOutputSchema>;
+
+// =============================================================================
+// Get Run Status
+// =============================================================================
+
+export const ApifyGetRunStatusInputSchema = z.object({
+    /** The actor run ID to check */
+    runId: z.string().min(1),
+});
+
+export const ApifyGetRunStatusOutputSchema = z.object({
+    runId: z.string(),
+    actorId: z.string(),
+    status: z.string(),
+    startedAt: z.string().nullable(),
+    finishedAt: z.string().nullable(),
+    defaultDatasetId: z.string(),
+    defaultKeyValueStoreId: z.string(),
+    defaultRequestQueueId: z.string(),
+});
+
+export type ApifyGetRunStatusInput = z.infer<typeof ApifyGetRunStatusInputSchema>;
+export type ApifyGetRunStatusOutput = z.infer<typeof ApifyGetRunStatusOutputSchema>;

--- a/packages/nodes/src/integrations/index.ts
+++ b/packages/nodes/src/integrations/index.ts
@@ -183,3 +183,23 @@ export {
   type WordPressUploadMediaInput,
   type WordPressUploadMediaOutput,
 } from './wordpress/index.js'
+
+// Apify integrations
+export {
+  apifyRunActorNode,
+  ApifyRunActorInputSchema,
+  ApifyRunActorOutputSchema,
+  type ApifyRunActorInput,
+  type ApifyRunActorOutput,
+  apifyGetDatasetNode,
+  ApifyGetDatasetInputSchema,
+  ApifyGetDatasetOutputSchema,
+  type ApifyGetDatasetInput,
+  type ApifyGetDatasetOutput,
+  apifyGetRunStatusNode,
+  ApifyGetRunStatusInputSchema,
+  ApifyGetRunStatusOutputSchema,
+  type ApifyGetRunStatusInput,
+  type ApifyGetRunStatusOutput,
+  apifyCredential,
+} from './apify/index.js'


### PR DESCRIPTION
Introduce Apify integration: adds Run Actor, Get Dataset, and Get Run Status nodes with Zod schemas and executors (including polling and retry behavior), plus an Apify bearer credential definition and unit tests. Also update core NodeCredentials to include apify.apiToken and export the new Apify integrations from the integrations index. (package-lock.json updated)