### PR TITLE
feat: add Airtable integration - database operations

### DIFF
--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -84,6 +84,10 @@ export interface NodeCredentials {
     refreshToken: string
     expiresAt: number
   }
+  /** Airtable API credentials */
+  airtable?: {
+    accessToken: string
+  }
 }
 
 /**

--- a/packages/nodes/src/index.ts
+++ b/packages/nodes/src/index.ts
@@ -196,6 +196,22 @@ export {
   readOutputSchema,
   updateInputSchema,
   updateOutputSchema,
+  // Airtable
+  airtableCreateRecordNode,
+  AirtableCreateRecordInputSchema,
+  AirtableCreateRecordOutputSchema,
+  airtableGetRecordsNode,
+  AirtableGetRecordsInputSchema,
+  AirtableGetRecordsOutputSchema,
+  airtableUpdateRecordNode,
+  AirtableUpdateRecordInputSchema,
+  AirtableUpdateRecordOutputSchema,
+  airtableDeleteRecordNode,
+  AirtableDeleteRecordInputSchema,
+  AirtableDeleteRecordOutputSchema,
+  AirtableRecordSchema,
+  AirtableSortSchema,
+  airtableCredential,
 } from './integrations/index.js'
 
 export type {
@@ -276,6 +292,17 @@ export type {
   ReadOutput,
   UpdateInput,
   UpdateOutput,
+  // Airtable
+  AirtableRecord,
+  AirtableSort,
+  AirtableCreateRecordInput,
+  AirtableCreateRecordOutput,
+  AirtableGetRecordsInput,
+  AirtableGetRecordsOutput,
+  AirtableUpdateRecordInput,
+  AirtableUpdateRecordOutput,
+  AirtableDeleteRecordInput,
+  AirtableDeleteRecordOutput,
 } from './integrations/index.js'
 
 // AI nodes
@@ -348,6 +375,10 @@ import {
   googleSheetsClearNode,
   googleSheetsReadNode,
   googleSheetsUpdateNode,
+  airtableCreateRecordNode as airtableCreateRecordNode_,
+  airtableGetRecordsNode as airtableGetRecordsNode_,
+  airtableUpdateRecordNode as airtableUpdateRecordNode_,
+  airtableDeleteRecordNode as airtableDeleteRecordNode_,
 } from './integrations/index.js'
 import {
   socialKeywordGeneratorNode,
@@ -407,6 +438,11 @@ export const builtInNodes = [
   googleSheetsClearNode,
   googleSheetsReadNode,
   googleSheetsUpdateNode,
+  // Airtable
+  airtableCreateRecordNode_,
+  airtableGetRecordsNode_,
+  airtableUpdateRecordNode_,
+  airtableDeleteRecordNode_,
   // AI
   socialKeywordGeneratorNode,
   draftEmailsNode,

--- a/packages/nodes/src/integrations/airtable/__tests__/airtable.test.ts
+++ b/packages/nodes/src/integrations/airtable/__tests__/airtable.test.ts
@@ -1,0 +1,688 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  airtableCredential,
+  airtableCreateRecordNode,
+  airtableGetRecordsNode,
+  airtableUpdateRecordNode,
+  airtableDeleteRecordNode,
+  AirtableCreateRecordInputSchema,
+  AirtableGetRecordsInputSchema,
+  AirtableUpdateRecordInputSchema,
+  AirtableDeleteRecordInputSchema,
+} from '../index.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const baseContext = {
+  userId: 'u1',
+  workflowExecutionId: 'w1',
+  variables: {},
+  resolveNestedPath: () => undefined,
+};
+
+const authedContext = {
+  ...baseContext,
+  credentials: { airtable: { accessToken: 'pat-test-token' } },
+};
+
+// ─── Credential metadata ────────────────────────────────────────────────────
+
+describe('airtable credentials', () => {
+  it('defines bearer credential metadata', () => {
+    expect(airtableCredential.name).toBe('airtable');
+    expect(airtableCredential.type).toBe('bearer');
+  });
+
+  it('includes correct authenticate config', () => {
+    expect(airtableCredential.authenticate.type).toBe('header');
+    expect(airtableCredential.authenticate.properties.Authorization).toBe(
+      'Bearer {{accessToken}}'
+    );
+  });
+});
+
+// ─── Schema validation ──────────────────────────────────────────────────────
+
+describe('airtable schemas', () => {
+  it('validates create record input with required fields', () => {
+    const result = AirtableCreateRecordInputSchema.safeParse({
+      baseId: 'appXXXXXXXXXX',
+      tableId: 'tblXXXXXXXXXX',
+      fields: { Name: 'Test' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects create record input missing fields', () => {
+    const result = AirtableCreateRecordInputSchema.safeParse({
+      baseId: 'appXXX',
+      tableId: 'tblXXX',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('validates get records input with optional fields', () => {
+    const result = AirtableGetRecordsInputSchema.safeParse({
+      baseId: 'appXXX',
+      tableId: 'tblXXX',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts get records input with filterByFormula', () => {
+    const result = AirtableGetRecordsInputSchema.safeParse({
+      baseId: 'appXXX',
+      tableId: 'tblXXX',
+      filterByFormula: '{Status} = "Active"',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('validates update record input', () => {
+    const result = AirtableUpdateRecordInputSchema.safeParse({
+      baseId: 'appXXX',
+      tableId: 'tblXXX',
+      recordId: 'recXXXXXXXXXX',
+      fields: { Name: 'Updated' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('validates delete record input', () => {
+    const result = AirtableDeleteRecordInputSchema.safeParse({
+      baseId: 'appXXX',
+      tableId: 'tblXXX',
+      recordId: 'recXXXXXXXXXX',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects delete record input missing recordId', () => {
+    const result = AirtableDeleteRecordInputSchema.safeParse({
+      baseId: 'appXXX',
+      tableId: 'tblXXX',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── airtableCreateRecord ───────────────────────────────────────────────────
+
+describe('airtable_create_record', () => {
+  it('fails when access token is missing', async () => {
+    const result = await airtableCreateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', fields: { Name: 'Test' } },
+      baseContext
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('airtable.accessToken');
+  });
+
+  it('creates record and returns id + fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'recABC123',
+          fields: { Name: 'Test', Status: 'Active' },
+          createdTime: '2024-01-01T00:00:00.000Z',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableCreateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', fields: { Name: 'Test', Status: 'Active' } },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.id).toBe('recABC123');
+      expect(result.output.fields).toEqual({ Name: 'Test', Status: 'Active' });
+      expect(result.output.createdTime).toBe('2024-01-01T00:00:00.000Z');
+    }
+  });
+
+  it('sends correct Authorization header', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 'rec1', fields: {}, createdTime: '2024-01-01T00:00:00.000Z' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await airtableCreateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', fields: {} },
+      authedContext
+    );
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((requestInit.headers as Record<string, string>).Authorization).toBe(
+      'Bearer pat-test-token'
+    );
+  });
+
+  it('sends correct request body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 'rec1', fields: { Name: 'Test' }, createdTime: '2024-01-01T00:00:00.000Z' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await airtableCreateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', fields: { Name: 'Test' } },
+      authedContext
+    );
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(requestInit.body));
+    expect(body.fields).toEqual({ Name: 'Test' });
+  });
+
+  it('returns error on API failure', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { type: 'TABLE_NOT_FOUND', message: 'Could not find table' } }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableCreateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblNotExist', fields: { Name: 'Test' } },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('404');
+  });
+
+  it('returns error on non-ok response status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"error":{"type":"INVALID_REQUEST"}}', {
+        status: 422,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableCreateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', fields: { BadField: 'value' } },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('422');
+  });
+
+  it('creates record with empty fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 'recEmpty1', fields: {}, createdTime: '2024-01-01T00:00:00.000Z' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableCreateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', fields: {} },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.id).toBe('recEmpty1');
+    }
+  });
+});
+
+// ─── airtableGetRecords ─────────────────────────────────────────────────────
+
+describe('airtable_get_records', () => {
+  it('fails when access token is missing', async () => {
+    const result = await airtableGetRecordsNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX' },
+      baseContext
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('airtable.accessToken');
+  });
+
+  it('returns records from table', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          records: [
+            { id: 'rec1', fields: { Name: 'Alice' }, createdTime: '2024-01-01T00:00:00.000Z' },
+            { id: 'rec2', fields: { Name: 'Bob' }, createdTime: '2024-01-02T00:00:00.000Z' },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableGetRecordsNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX' },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.records).toHaveLength(2);
+      expect(result.output.records[0]?.id).toBe('rec1');
+      expect(result.output.records[1]?.fields).toEqual({ Name: 'Bob' });
+    }
+  });
+
+  it('sends filterByFormula as query param', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ records: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await airtableGetRecordsNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', filterByFormula: '{Status} = "Active"' },
+      authedContext
+    );
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    const params = new URLSearchParams(url.split('?')[1]);
+    expect(params.get('filterByFormula')).toBe('{Status} = "Active"');
+  });
+
+  it('sends sort as query params', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ records: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await airtableGetRecordsNode.executor(
+      {
+        baseId: 'appXXX',
+        tableId: 'tblXXX',
+        sort: [{ field: 'Name', direction: 'asc' as const }],
+      },
+      authedContext
+    );
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('sort%5B0%5D%5Bfield%5D=Name');
+    expect(url).toContain('sort%5B0%5D%5Bdirection%5D=asc');
+  });
+
+  it('sends multi-sort correctly', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ records: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await airtableGetRecordsNode.executor(
+      {
+        baseId: 'appXXX',
+        tableId: 'tblXXX',
+        sort: [
+          { field: 'Name', direction: 'asc' as const },
+          { field: 'Date', direction: 'desc' as const },
+        ],
+      },
+      authedContext
+    );
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('sort%5B0%5D%5Bfield%5D=Name');
+    expect(url).toContain('sort%5B1%5D%5Bfield%5D=Date');
+    expect(url).toContain('sort%5B1%5D%5Bdirection%5D=desc');
+  });
+
+  it('sends maxRecords as query param', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ records: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await airtableGetRecordsNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', maxRecords: 10 },
+      authedContext
+    );
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('maxRecords=10');
+  });
+
+  it('URL-encodes filterByFormula with special chars', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ records: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const formula = `AND({Name}="O'Brien", {Age}>30)`;
+    await airtableGetRecordsNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', filterByFormula: formula },
+      authedContext
+    );
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    // The formula should be properly encoded in the query string
+    const params = new URLSearchParams(url.split('?')[1]);
+    expect(params.get('filterByFormula')).toBe(formula);
+  });
+
+  it('returns offset for pagination', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          records: [{ id: 'rec1', fields: {}, createdTime: '2024-01-01T00:00:00.000Z' }],
+          offset: 'itr12345/rec67890',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableGetRecordsNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX' },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.offset).toBe('itr12345/rec67890');
+    }
+  });
+
+  it('handles empty table', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ records: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableGetRecordsNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX' },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.records).toHaveLength(0);
+    }
+  });
+
+  it('returns error on API failure', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"error":{"type":"NOT_FOUND"}}', {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableGetRecordsNode.executor(
+      { baseId: 'appXXX', tableId: 'tblNotExist' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('404');
+  });
+});
+
+// ─── airtableUpdateRecord ───────────────────────────────────────────────────
+
+describe('airtable_update_record', () => {
+  it('fails when access token is missing', async () => {
+    const result = await airtableUpdateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', recordId: 'recXXX', fields: { Name: 'Updated' } },
+      baseContext
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('airtable.accessToken');
+  });
+
+  it('updates record and returns updated fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'recABC123',
+          fields: { Name: 'Updated', Status: 'Done' },
+          createdTime: '2024-01-01T00:00:00.000Z',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableUpdateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', recordId: 'recABC123', fields: { Name: 'Updated' } },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.id).toBe('recABC123');
+      expect(result.output.fields).toEqual({ Name: 'Updated', Status: 'Done' });
+    }
+  });
+
+  it('sends PATCH to correct URL with recordId', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 'recABC', fields: {}, createdTime: '2024-01-01T00:00:00.000Z' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await airtableUpdateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblYYY', recordId: 'recABC', fields: { Name: 'Test' } },
+      authedContext
+    );
+
+    const [url, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('appXXX/tblYYY/recABC');
+    expect(requestInit.method).toBe('PATCH');
+  });
+
+  it('sends only specified fields in body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 'rec1', fields: { Name: 'New' }, createdTime: '2024-01-01T00:00:00.000Z' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await airtableUpdateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', recordId: 'rec1', fields: { Name: 'New' } },
+      authedContext
+    );
+
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(requestInit.body));
+    expect(body.fields).toEqual({ Name: 'New' });
+    expect(Object.keys(body)).toEqual(['fields']);
+  });
+
+  it('returns error on API failure', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"error":{"type":"RECORD_NOT_FOUND"}}', {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableUpdateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', recordId: 'recNotExist', fields: { Name: 'X' } },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('404');
+  });
+});
+
+// ─── airtableDeleteRecord ───────────────────────────────────────────────────
+
+describe('airtable_delete_record', () => {
+  it('fails when access token is missing', async () => {
+    const result = await airtableDeleteRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', recordId: 'recXXX' },
+      baseContext
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('airtable.accessToken');
+  });
+
+  it('deletes record and returns confirmation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 'recABC123', deleted: true }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableDeleteRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', recordId: 'recABC123' },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.id).toBe('recABC123');
+      expect(result.output.deleted).toBe(true);
+    }
+  });
+
+  it('sends DELETE to correct URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 'recABC', deleted: true }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await airtableDeleteRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblYYY', recordId: 'recABC' },
+      authedContext
+    );
+
+    const [url, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('appXXX/tblYYY/recABC');
+    expect(requestInit.method).toBe('DELETE');
+  });
+
+  it('returns error on API failure', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"error":{"type":"RECORD_NOT_FOUND"}}', {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await airtableDeleteRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', recordId: 'recNotExist' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('404');
+  });
+});
+
+// ─── Integration: Full CRUD flow ────────────────────────────────────────────
+
+describe('airtable full CRUD flow', () => {
+  it('create -> get -> update -> delete', async () => {
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init: RequestInit) => {
+      callCount++;
+      if (init.method === 'POST') {
+        return new Response(
+          JSON.stringify({ id: 'recNew1', fields: { Name: 'Created' }, createdTime: '2024-01-01T00:00:00.000Z' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (init.method === 'GET') {
+        return new Response(
+          JSON.stringify({
+            records: [{ id: 'recNew1', fields: { Name: 'Created' }, createdTime: '2024-01-01T00:00:00.000Z' }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (init.method === 'PATCH') {
+        return new Response(
+          JSON.stringify({ id: 'recNew1', fields: { Name: 'Updated' }, createdTime: '2024-01-01T00:00:00.000Z' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (init.method === 'DELETE') {
+        return new Response(
+          JSON.stringify({ id: 'recNew1', deleted: true }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      throw new Error(`Unexpected: ${init.method}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Create
+    const createResult = await airtableCreateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', fields: { Name: 'Created' } },
+      authedContext
+    );
+    expect(createResult.success).toBe(true);
+
+    // Get
+    const getResult = await airtableGetRecordsNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX' },
+      authedContext
+    );
+    expect(getResult.success).toBe(true);
+
+    // Update
+    const updateResult = await airtableUpdateRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', recordId: 'recNew1', fields: { Name: 'Updated' } },
+      authedContext
+    );
+    expect(updateResult.success).toBe(true);
+
+    // Delete
+    const deleteResult = await airtableDeleteRecordNode.executor(
+      { baseId: 'appXXX', tableId: 'tblXXX', recordId: 'recNew1' },
+      authedContext
+    );
+    expect(deleteResult.success).toBe(true);
+
+    expect(callCount).toBe(4);
+  });
+});

--- a/packages/nodes/src/integrations/airtable/airtable-create-record.ts
+++ b/packages/nodes/src/integrations/airtable/airtable-create-record.ts
@@ -1,0 +1,83 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry } from '../../utils/http.js';
+import {
+  AirtableCreateRecordInputSchema,
+  AirtableCreateRecordOutputSchema,
+  type AirtableCreateRecordInput,
+  type AirtableCreateRecordOutput,
+} from './schemas.js';
+
+export {
+  AirtableCreateRecordInputSchema,
+  AirtableCreateRecordOutputSchema,
+  type AirtableCreateRecordInput,
+  type AirtableCreateRecordOutput,
+} from './schemas.js';
+
+const AIRTABLE_API_BASE = 'https://api.airtable.com/v0';
+
+interface AirtableRecordResponse {
+  id: string;
+  fields: Record<string, unknown>;
+  createdTime: string;
+}
+
+export const airtableCreateRecordNode = defineNode({
+  type: 'airtable_create_record',
+  name: 'Airtable Create Record',
+  description: 'Create a new record in an Airtable table',
+  category: 'integration',
+  inputSchema: AirtableCreateRecordInputSchema,
+  outputSchema: AirtableCreateRecordOutputSchema,
+  estimatedDuration: 5,
+  capabilities: {
+    supportsRerun: true,
+  },
+  executor: async (input: AirtableCreateRecordInput, context) => {
+    try {
+      const accessToken = context.credentials?.airtable?.accessToken;
+      if (!accessToken) {
+        return {
+          success: false,
+          error: 'Airtable access token not configured. Please provide context.credentials.airtable.accessToken.',
+        };
+      }
+
+      const response = await fetchWithRetry(
+        `${AIRTABLE_API_BASE}/${input.baseId}/${encodeURIComponent(input.tableId)}`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ fields: input.fields }),
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return {
+          success: false,
+          error: `Airtable API error: ${response.status} - ${errorText}`,
+        };
+      }
+
+      const data = (await response.json()) as AirtableRecordResponse;
+
+      const output: AirtableCreateRecordOutput = {
+        id: data.id,
+        fields: data.fields,
+        createdTime: data.createdTime,
+      };
+
+      return { success: true, output };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to create Airtable record',
+      };
+    }
+  },
+});

--- a/packages/nodes/src/integrations/airtable/airtable-delete-record.ts
+++ b/packages/nodes/src/integrations/airtable/airtable-delete-record.ts
@@ -1,0 +1,79 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry } from '../../utils/http.js';
+import {
+  AirtableDeleteRecordInputSchema,
+  AirtableDeleteRecordOutputSchema,
+  type AirtableDeleteRecordInput,
+  type AirtableDeleteRecordOutput,
+} from './schemas.js';
+
+export {
+  AirtableDeleteRecordInputSchema,
+  AirtableDeleteRecordOutputSchema,
+  type AirtableDeleteRecordInput,
+  type AirtableDeleteRecordOutput,
+} from './schemas.js';
+
+const AIRTABLE_API_BASE = 'https://api.airtable.com/v0';
+
+interface AirtableDeleteResponse {
+  id: string;
+  deleted: boolean;
+}
+
+export const airtableDeleteRecordNode = defineNode({
+  type: 'airtable_delete_record',
+  name: 'Airtable Delete Record',
+  description: 'Delete a record from an Airtable table',
+  category: 'integration',
+  inputSchema: AirtableDeleteRecordInputSchema,
+  outputSchema: AirtableDeleteRecordOutputSchema,
+  estimatedDuration: 5,
+  capabilities: {
+    supportsRerun: true,
+  },
+  executor: async (input: AirtableDeleteRecordInput, context) => {
+    try {
+      const accessToken = context.credentials?.airtable?.accessToken;
+      if (!accessToken) {
+        return {
+          success: false,
+          error: 'Airtable access token not configured. Please provide context.credentials.airtable.accessToken.',
+        };
+      }
+
+      const response = await fetchWithRetry(
+        `${AIRTABLE_API_BASE}/${input.baseId}/${encodeURIComponent(input.tableId)}/${input.recordId}`,
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return {
+          success: false,
+          error: `Airtable API error: ${response.status} - ${errorText}`,
+        };
+      }
+
+      const data = (await response.json()) as AirtableDeleteResponse;
+
+      const output: AirtableDeleteRecordOutput = {
+        id: data.id,
+        deleted: data.deleted,
+      };
+
+      return { success: true, output };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to delete Airtable record',
+      };
+    }
+  },
+});

--- a/packages/nodes/src/integrations/airtable/airtable-get-records.ts
+++ b/packages/nodes/src/integrations/airtable/airtable-get-records.ts
@@ -1,0 +1,110 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry } from '../../utils/http.js';
+import {
+  AirtableGetRecordsInputSchema,
+  AirtableGetRecordsOutputSchema,
+  type AirtableGetRecordsInput,
+  type AirtableGetRecordsOutput,
+} from './schemas.js';
+
+export {
+  AirtableGetRecordsInputSchema,
+  AirtableGetRecordsOutputSchema,
+  type AirtableGetRecordsInput,
+  type AirtableGetRecordsOutput,
+} from './schemas.js';
+
+const AIRTABLE_API_BASE = 'https://api.airtable.com/v0';
+
+interface AirtableListResponse {
+  records: Array<{
+    id: string;
+    fields: Record<string, unknown>;
+    createdTime: string;
+  }>;
+  offset?: string;
+}
+
+export const airtableGetRecordsNode = defineNode({
+  type: 'airtable_get_records',
+  name: 'Airtable Get Records',
+  description: 'List records from an Airtable table with optional filtering, sorting, and pagination',
+  category: 'integration',
+  inputSchema: AirtableGetRecordsInputSchema,
+  outputSchema: AirtableGetRecordsOutputSchema,
+  estimatedDuration: 5,
+  capabilities: {
+    supportsRerun: true,
+  },
+  executor: async (input: AirtableGetRecordsInput, context) => {
+    try {
+      const accessToken = context.credentials?.airtable?.accessToken;
+      if (!accessToken) {
+        return {
+          success: false,
+          error: 'Airtable access token not configured. Please provide context.credentials.airtable.accessToken.',
+        };
+      }
+
+      const params = new URLSearchParams();
+
+      if (input.filterByFormula) {
+        params.set('filterByFormula', input.filterByFormula);
+      }
+
+      if (input.maxRecords !== undefined) {
+        params.set('maxRecords', String(input.maxRecords));
+      }
+
+      if (input.sort) {
+        for (let i = 0; i < input.sort.length; i++) {
+          const s = input.sort[i]!;
+          params.set(`sort[${i}][field]`, s.field);
+          if (s.direction) {
+            params.set(`sort[${i}][direction]`, s.direction);
+          }
+        }
+      }
+
+      const queryString = params.toString();
+      const url = `${AIRTABLE_API_BASE}/${input.baseId}/${encodeURIComponent(input.tableId)}${queryString ? `?${queryString}` : ''}`;
+
+      const response = await fetchWithRetry(
+        url,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return {
+          success: false,
+          error: `Airtable API error: ${response.status} - ${errorText}`,
+        };
+      }
+
+      const data = (await response.json()) as AirtableListResponse;
+
+      const output: AirtableGetRecordsOutput = {
+        records: data.records.map((r) => ({
+          id: r.id,
+          fields: r.fields,
+          createdTime: r.createdTime,
+        })),
+        offset: data.offset,
+      };
+
+      return { success: true, output };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to get Airtable records',
+      };
+    }
+  },
+});

--- a/packages/nodes/src/integrations/airtable/airtable-update-record.ts
+++ b/packages/nodes/src/integrations/airtable/airtable-update-record.ts
@@ -1,0 +1,83 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry } from '../../utils/http.js';
+import {
+  AirtableUpdateRecordInputSchema,
+  AirtableUpdateRecordOutputSchema,
+  type AirtableUpdateRecordInput,
+  type AirtableUpdateRecordOutput,
+} from './schemas.js';
+
+export {
+  AirtableUpdateRecordInputSchema,
+  AirtableUpdateRecordOutputSchema,
+  type AirtableUpdateRecordInput,
+  type AirtableUpdateRecordOutput,
+} from './schemas.js';
+
+const AIRTABLE_API_BASE = 'https://api.airtable.com/v0';
+
+interface AirtableRecordResponse {
+  id: string;
+  fields: Record<string, unknown>;
+  createdTime: string;
+}
+
+export const airtableUpdateRecordNode = defineNode({
+  type: 'airtable_update_record',
+  name: 'Airtable Update Record',
+  description: 'Update an existing record in an Airtable table (partial update via PATCH)',
+  category: 'integration',
+  inputSchema: AirtableUpdateRecordInputSchema,
+  outputSchema: AirtableUpdateRecordOutputSchema,
+  estimatedDuration: 5,
+  capabilities: {
+    supportsRerun: true,
+  },
+  executor: async (input: AirtableUpdateRecordInput, context) => {
+    try {
+      const accessToken = context.credentials?.airtable?.accessToken;
+      if (!accessToken) {
+        return {
+          success: false,
+          error: 'Airtable access token not configured. Please provide context.credentials.airtable.accessToken.',
+        };
+      }
+
+      const response = await fetchWithRetry(
+        `${AIRTABLE_API_BASE}/${input.baseId}/${encodeURIComponent(input.tableId)}/${input.recordId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ fields: input.fields }),
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return {
+          success: false,
+          error: `Airtable API error: ${response.status} - ${errorText}`,
+        };
+      }
+
+      const data = (await response.json()) as AirtableRecordResponse;
+
+      const output: AirtableUpdateRecordOutput = {
+        id: data.id,
+        fields: data.fields,
+        createdTime: data.createdTime,
+      };
+
+      return { success: true, output };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to update Airtable record',
+      };
+    }
+  },
+});

--- a/packages/nodes/src/integrations/airtable/credentials.ts
+++ b/packages/nodes/src/integrations/airtable/credentials.ts
@@ -1,0 +1,17 @@
+import { defineBearerCredential } from '@jam-nodes/core';
+import { z } from 'zod';
+
+export const airtableCredential = defineBearerCredential({
+  name: 'airtable',
+  displayName: 'Airtable API Token',
+  documentationUrl: 'https://airtable.com/developers/web/api/introduction',
+  schema: z.object({
+    accessToken: z.string(),
+  }),
+  authenticate: {
+    type: 'header',
+    properties: {
+      Authorization: 'Bearer {{accessToken}}',
+    },
+  },
+});

--- a/packages/nodes/src/integrations/airtable/index.ts
+++ b/packages/nodes/src/integrations/airtable/index.ts
@@ -1,0 +1,41 @@
+export {
+  airtableCreateRecordNode,
+  AirtableCreateRecordInputSchema,
+  AirtableCreateRecordOutputSchema,
+  type AirtableCreateRecordInput,
+  type AirtableCreateRecordOutput,
+} from './airtable-create-record.js';
+
+export {
+  airtableGetRecordsNode,
+  AirtableGetRecordsInputSchema,
+  AirtableGetRecordsOutputSchema,
+  type AirtableGetRecordsInput,
+  type AirtableGetRecordsOutput,
+} from './airtable-get-records.js';
+
+export {
+  airtableUpdateRecordNode,
+  AirtableUpdateRecordInputSchema,
+  AirtableUpdateRecordOutputSchema,
+  type AirtableUpdateRecordInput,
+  type AirtableUpdateRecordOutput,
+} from './airtable-update-record.js';
+
+export {
+  airtableDeleteRecordNode,
+  AirtableDeleteRecordInputSchema,
+  AirtableDeleteRecordOutputSchema,
+  type AirtableDeleteRecordInput,
+  type AirtableDeleteRecordOutput,
+} from './airtable-delete-record.js';
+
+export {
+  AirtableRecordSchema,
+  AirtableSortSchema,
+  AirtableDeleteRecordInputSchema as AirtableDeleteInputSchema,
+  type AirtableRecord,
+  type AirtableSort,
+} from './schemas.js';
+
+export { airtableCredential } from './credentials.js';

--- a/packages/nodes/src/integrations/airtable/schemas.ts
+++ b/packages/nodes/src/integrations/airtable/schemas.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+// ----- Shared sub-schemas -----
+
+export const AirtableRecordSchema = z.object({
+  id: z.string(),
+  fields: z.record(z.unknown()),
+  createdTime: z.string(),
+});
+
+export const AirtableSortSchema = z.object({
+  field: z.string().min(1),
+  direction: z.enum(['asc', 'desc']).optional().default('asc'),
+});
+
+// ----- airtableCreateRecord -----
+
+export const AirtableCreateRecordInputSchema = z.object({
+  baseId: z.string().min(1, 'Base ID is required'),
+  tableId: z.string().min(1, 'Table ID is required'),
+  fields: z.record(z.unknown()),
+});
+
+export const AirtableCreateRecordOutputSchema = AirtableRecordSchema;
+
+// ----- airtableGetRecords -----
+
+export const AirtableGetRecordsInputSchema = z.object({
+  baseId: z.string().min(1, 'Base ID is required'),
+  tableId: z.string().min(1, 'Table ID is required'),
+  filterByFormula: z.string().optional(),
+  sort: z.array(AirtableSortSchema).optional(),
+  maxRecords: z.number().int().positive().optional(),
+});
+
+export const AirtableGetRecordsOutputSchema = z.object({
+  records: z.array(AirtableRecordSchema),
+  offset: z.string().optional(),
+});
+
+// ----- airtableUpdateRecord -----
+
+export const AirtableUpdateRecordInputSchema = z.object({
+  baseId: z.string().min(1, 'Base ID is required'),
+  tableId: z.string().min(1, 'Table ID is required'),
+  recordId: z.string().min(1, 'Record ID is required'),
+  fields: z.record(z.unknown()),
+});
+
+export const AirtableUpdateRecordOutputSchema = AirtableRecordSchema;
+
+// ----- airtableDeleteRecord -----
+
+export const AirtableDeleteRecordInputSchema = z.object({
+  baseId: z.string().min(1, 'Base ID is required'),
+  tableId: z.string().min(1, 'Table ID is required'),
+  recordId: z.string().min(1, 'Record ID is required'),
+});
+
+export const AirtableDeleteRecordOutputSchema = z.object({
+  id: z.string(),
+  deleted: z.boolean(),
+});
+
+// ----- Inferred types -----
+
+export type AirtableRecord = z.infer<typeof AirtableRecordSchema>;
+export type AirtableSort = z.infer<typeof AirtableSortSchema>;
+
+export type AirtableCreateRecordInput = z.infer<typeof AirtableCreateRecordInputSchema>;
+export type AirtableCreateRecordOutput = z.infer<typeof AirtableCreateRecordOutputSchema>;
+
+export type AirtableGetRecordsInput = z.infer<typeof AirtableGetRecordsInputSchema>;
+export type AirtableGetRecordsOutput = z.infer<typeof AirtableGetRecordsOutputSchema>;
+
+export type AirtableUpdateRecordInput = z.infer<typeof AirtableUpdateRecordInputSchema>;
+export type AirtableUpdateRecordOutput = z.infer<typeof AirtableUpdateRecordOutputSchema>;
+
+export type AirtableDeleteRecordInput = z.infer<typeof AirtableDeleteRecordInputSchema>;
+export type AirtableDeleteRecordOutput = z.infer<typeof AirtableDeleteRecordOutputSchema>;

--- a/packages/nodes/src/integrations/index.ts
+++ b/packages/nodes/src/integrations/index.ts
@@ -275,3 +275,32 @@ export {
   type SlackSearchMatch,
   slackCredential,
 } from './slack/index.js'
+
+// Airtable integrations
+export {
+  airtableCreateRecordNode,
+  AirtableCreateRecordInputSchema,
+  AirtableCreateRecordOutputSchema,
+  type AirtableCreateRecordInput,
+  type AirtableCreateRecordOutput,
+  airtableGetRecordsNode,
+  AirtableGetRecordsInputSchema,
+  AirtableGetRecordsOutputSchema,
+  type AirtableGetRecordsInput,
+  type AirtableGetRecordsOutput,
+  airtableUpdateRecordNode,
+  AirtableUpdateRecordInputSchema,
+  AirtableUpdateRecordOutputSchema,
+  type AirtableUpdateRecordInput,
+  type AirtableUpdateRecordOutput,
+  airtableDeleteRecordNode,
+  AirtableDeleteRecordInputSchema,
+  AirtableDeleteRecordOutputSchema,
+  type AirtableDeleteRecordInput,
+  type AirtableDeleteRecordOutput,
+  AirtableRecordSchema,
+  AirtableSortSchema,
+  type AirtableRecord,
+  type AirtableSort,
+  airtableCredential,
+} from './airtable/index.js'


### PR DESCRIPTION
 ## Summary

  Adds Airtable integration for database operations per Issue #29 (P1 priority). Implements a bearer token credential and 4 CRUD operation nodes following the
  existing Slack/DevTo integration patterns.

  ## Credential

  - Uses `defineBearerCredential` from `@jam-nodes/core`
  - Name: `airtable`, type: `bearer`
  - Authentication via `Authorization: Bearer {{accessToken}}` header
  - Added `airtable?: { accessToken: string }` to `NodeCredentials` interface in core

  ## Operations

  ### airtableCreateRecord
  - **Input**: `{ baseId, tableId, fields }`
  - **API**: `POST https://api.airtable.com/v0/{baseId}/{tableId}`
  - **Body**: `{ fields: {...} }`
  - **Output**: `{ id, fields, createdTime }`

  ### airtableGetRecords
  - **Input**: `{ baseId, tableId, filterByFormula?, sort?, maxRecords? }`
  - **API**: `GET https://api.airtable.com/v0/{baseId}/{tableId}` with query params
  - **Features**:
    - `filterByFormula` — URL-encoded, supports special characters (e.g. `AND({Name}="O'Brien", {Age}>30)`)
    - `sort` — Airtable bracket notation (`sort[0][field]=Name&sort[0][direction]=asc`), supports multiple sort fields
    - `maxRecords` — integer limit
    - Pagination — returns `offset` token from Airtable response for subsequent requests
  - **Output**: `{ records: [{ id, fields, createdTime }], offset? }`

  ### airtableUpdateRecord
  - **Input**: `{ baseId, tableId, recordId, fields }`
  - **API**: `PATCH https://api.airtable.com/v0/{baseId}/{tableId}/{recordId}`
  - **Body**: `{ fields: {...} }` (partial update — only specified fields are changed)
  - **Output**: `{ id, fields, createdTime }`

  ### airtableDeleteRecord
  - **Input**: `{ baseId, tableId, recordId }`
  - **API**: `DELETE https://api.airtable.com/v0/{baseId}/{tableId}/{recordId}`
  - **Output**: `{ id, deleted }`

  ## Architecture

  - Each operation is a separate file following the Slack pattern (`slack-send-message.ts`, etc.)
  - All nodes use `defineNode` from `@jam-nodes/core` with category `integration`
  - HTTP calls use the shared `fetchWithRetry` utility which handles rate limiting (429), retries with exponential backoff, and timeouts
  - Credentials flow through `context.credentials.airtable.accessToken` matching the `NodeCredentials` pattern
  - `tableId` is URL-encoded via `encodeURIComponent` to handle table names with spaces
  - Zod schemas for all inputs/outputs with inferred TypeScript types
  - All error paths return `{ success: false, error }` — no thrown exceptions

  ## Files Changed

  ### New files (8)
  - `packages/nodes/src/integrations/airtable/credentials.ts` — bearer credential definition
  - `packages/nodes/src/integrations/airtable/schemas.ts` — Zod input/output schemas + inferred types
  - `packages/nodes/src/integrations/airtable/airtable-create-record.ts` — create operation
  - `packages/nodes/src/integrations/airtable/airtable-get-records.ts` — get/list operation with filtering, sorting, pagination
  - `packages/nodes/src/integrations/airtable/airtable-update-record.ts` — update operation (PATCH)
  - `packages/nodes/src/integrations/airtable/airtable-delete-record.ts` — delete operation
  - `packages/nodes/src/integrations/airtable/index.ts` — barrel exports
  - `packages/nodes/src/integrations/airtable/__tests__/airtable.test.ts` — 36 unit tests

  ### Modified files (3)
  - `packages/core/src/types/node.ts` — added `airtable` to `NodeCredentials` interface
  - `packages/nodes/src/integrations/index.ts` — added airtable exports
  - `packages/nodes/src/index.ts` — added airtable exports + registered 4 nodes in `builtInNodes`

  ## Test Plan

  36 tests covering:

  - **Credential metadata** (2): verifies name, type, and authenticate config
  - **Schema validation** (7): accepts valid inputs, rejects missing required fields for all operations
  - **airtableCreateRecord** (7): missing credentials, success response, auth header, request body, API errors (404, 422), empty fields
  - **airtableGetRecords** (10): missing credentials, multi-record response, filterByFormula encoding, single sort, multi-sort bracket notation, maxRecords,
  special character formula encoding, pagination offset, empty table, API error
  - **airtableUpdateRecord** (5): missing credentials, success with updated fields, PATCH method + URL verification, partial update body, API error
  - **airtableDeleteRecord** (4): missing credentials, success confirmation, DELETE method + URL verification, API error
  - **Full CRUD integration flow** (1): create → get → update → delete sequence with mocked responses

  **Results**: 36/36 passing, 0 regressions (231 total suite, baseline 195)