### PR TITLE
feat: add Clearbit integration (person/company enrichment + autocomplete)

### DIFF
--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -41,6 +41,10 @@ export interface NodeCredentials {
   forumScout?: {
     apiKey: string
   }
+  /** Clearbit API credentials (for person and company enrichment) */
+  clearbit?: {
+    apiKey: string
+  }
   /** DataForSEO API credentials */
   dataForSeo?: {
     /** Base64 encoded login:password */

--- a/packages/nodes/src/index.ts
+++ b/packages/nodes/src/index.ts
@@ -196,6 +196,17 @@ export {
   readOutputSchema,
   updateInputSchema,
   updateOutputSchema,
+  // Clearbit
+  clearbitCredential,
+  clearbitEnrichPersonNode,
+  ClearbitEnrichPersonInputSchema,
+  ClearbitEnrichPersonOutputSchema,
+  clearbitEnrichCompanyNode,
+  ClearbitEnrichCompanyInputSchema,
+  ClearbitEnrichCompanyOutputSchema,
+  clearbitCompanyAutocompleteNode,
+  ClearbitCompanyAutocompleteInputSchema,
+  ClearbitCompanyAutocompleteOutputSchema,
 } from './integrations/index.js'
 
 export type {
@@ -276,6 +287,13 @@ export type {
   ReadOutput,
   UpdateInput,
   UpdateOutput,
+  // Clearbit
+  ClearbitEnrichPersonInput,
+  ClearbitEnrichPersonOutput,
+  ClearbitEnrichCompanyInput,
+  ClearbitEnrichCompanyOutput,
+  ClearbitCompanyAutocompleteInput,
+  ClearbitCompanyAutocompleteOutput,
 } from './integrations/index.js'
 
 // AI nodes
@@ -348,6 +366,9 @@ import {
   googleSheetsClearNode,
   googleSheetsReadNode,
   googleSheetsUpdateNode,
+  clearbitEnrichPersonNode as clearbitEnrichPersonNode_,
+  clearbitEnrichCompanyNode as clearbitEnrichCompanyNode_,
+  clearbitCompanyAutocompleteNode as clearbitCompanyAutocompleteNode_,
 } from './integrations/index.js'
 import {
   socialKeywordGeneratorNode,
@@ -407,6 +428,10 @@ export const builtInNodes = [
   googleSheetsClearNode,
   googleSheetsReadNode,
   googleSheetsUpdateNode,
+  // Clearbit
+  clearbitEnrichPersonNode_,
+  clearbitEnrichCompanyNode_,
+  clearbitCompanyAutocompleteNode_,
   // AI
   socialKeywordGeneratorNode,
   draftEmailsNode,

--- a/packages/nodes/src/integrations/clearbit/__tests__/clearbit.test.ts
+++ b/packages/nodes/src/integrations/clearbit/__tests__/clearbit.test.ts
@@ -1,0 +1,734 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearbitCredential,
+  clearbitEnrichPersonNode,
+  clearbitEnrichCompanyNode,
+  clearbitCompanyAutocompleteNode,
+  ClearbitEnrichPersonInputSchema,
+  ClearbitEnrichCompanyInputSchema,
+  ClearbitCompanyAutocompleteInputSchema,
+} from '../index.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const baseContext = {
+  userId: 'u1',
+  workflowExecutionId: 'w1',
+  variables: {},
+  resolveNestedPath: () => undefined,
+};
+
+const authedContext = {
+  ...baseContext,
+  credentials: { clearbit: { apiKey: 'test-clearbit-key' } },
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// ─── Credential metadata ──────────────────────────────────────────────────────
+
+describe('clearbit credential', () => {
+  it('defines apiKey credential metadata', () => {
+    expect(clearbitCredential.name).toBe('clearbit');
+    expect(clearbitCredential.type).toBe('apiKey');
+    expect(clearbitCredential.displayName).toBe('Clearbit API');
+  });
+
+  it('uses header Bearer authentication', () => {
+    expect(clearbitCredential.authenticate.type).toBe('header');
+    expect(clearbitCredential.authenticate.properties.Authorization).toBe('Bearer {{apiKey}}');
+  });
+
+  it('includes documentation URL', () => {
+    expect(clearbitCredential.documentationUrl).toBe('https://clearbit.com/docs');
+  });
+
+  it('schema accepts valid apiKey', () => {
+    const result = clearbitCredential.schema.safeParse({ apiKey: 'test-key' });
+    expect(result.success).toBe(true);
+  });
+
+  it('schema rejects missing apiKey', () => {
+    const result = clearbitCredential.schema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── Schema validation ────────────────────────────────────────────────────────
+
+describe('clearbit schemas', () => {
+  // Enrich Person
+  it('validates enrich person input with email only', () => {
+    const result = ClearbitEnrichPersonInputSchema.safeParse({ email: 'alex@clearbit.com' });
+    expect(result.success).toBe(true);
+  });
+
+  it('validates enrich person input with all optional fields', () => {
+    const result = ClearbitEnrichPersonInputSchema.safeParse({
+      email: 'alex@clearbit.com',
+      givenName: 'Alex',
+      familyName: 'MacCaw',
+      company: 'Clearbit',
+      companyDomain: 'clearbit.com',
+      linkedIn: 'https://linkedin.com/in/alexmaccaw',
+      twitter: 'maccaw',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects enrich person input missing email', () => {
+    const result = ClearbitEnrichPersonInputSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects enrich person input with empty email', () => {
+    const result = ClearbitEnrichPersonInputSchema.safeParse({ email: '' });
+    expect(result.success).toBe(false);
+  });
+
+  // Enrich Company
+  it('validates enrich company input with domain', () => {
+    const result = ClearbitEnrichCompanyInputSchema.safeParse({ domain: 'stripe.com' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects enrich company input missing domain', () => {
+    const result = ClearbitEnrichCompanyInputSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects enrich company input with empty domain', () => {
+    const result = ClearbitEnrichCompanyInputSchema.safeParse({ domain: '' });
+    expect(result.success).toBe(false);
+  });
+
+  // Company Autocomplete
+  it('validates autocomplete input with name', () => {
+    const result = ClearbitCompanyAutocompleteInputSchema.safeParse({ name: 'stripe' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects autocomplete input missing name', () => {
+    const result = ClearbitCompanyAutocompleteInputSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects autocomplete input with empty name', () => {
+    const result = ClearbitCompanyAutocompleteInputSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── clearbit_enrich_person ───────────────────────────────────────────────────
+
+const mockPersonResponse = {
+  id: 'd54c54ad-40be-4305-8a34-0ab44710b90d',
+  name: {
+    fullName: 'Alex MacCaw',
+    givenName: 'Alex',
+    familyName: 'MacCaw',
+  },
+  email: 'alex@clearbit.com',
+  location: 'San Francisco, CA, USA',
+  employment: {
+    domain: 'clearbit.com',
+    name: 'Clearbit',
+    title: 'CEO',
+    role: 'leadership',
+    seniority: 'executive',
+  },
+  linkedin: { handle: 'alexmaccaw' },
+  twitter: { handle: 'maccaw', followers: 15248 },
+  facebook: { handle: 'amaccaw' },
+  github: { handle: 'maccman' },
+};
+
+describe('clearbit_enrich_person', () => {
+  it('fails when apiKey is missing', async () => {
+    const result = await clearbitEnrichPersonNode.executor(
+      { email: 'alex@clearbit.com' },
+      baseContext
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('context.credentials.clearbit.apiKey');
+  });
+
+  it('enriches person by email', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockPersonResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichPersonNode.executor(
+      { email: 'alex@clearbit.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toEqual({
+      id: 'd54c54ad-40be-4305-8a34-0ab44710b90d',
+      name: {
+        fullName: 'Alex MacCaw',
+        givenName: 'Alex',
+        familyName: 'MacCaw',
+      },
+      email: 'alex@clearbit.com',
+      location: 'San Francisco, CA, USA',
+      employment: {
+        domain: 'clearbit.com',
+        name: 'Clearbit',
+        title: 'CEO',
+        role: 'leadership',
+        seniority: 'executive',
+      },
+      social: {
+        linkedin: { handle: 'alexmaccaw' },
+        twitter: { handle: 'maccaw', followers: 15248 },
+        facebook: { handle: 'amaccaw' },
+        github: { handle: 'maccman' },
+      },
+    });
+  });
+
+  it('targets the person-stream endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockPersonResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitEnrichPersonNode.executor({ email: 'alex@clearbit.com' }, authedContext);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('https://person-stream.clearbit.com/v2/people/find');
+  });
+
+  it('sends Authorization Bearer header on request', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockPersonResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitEnrichPersonNode.executor({ email: 'alex@clearbit.com' }, authedContext);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-clearbit-key');
+  });
+
+  it('sends email as query param', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockPersonResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitEnrichPersonNode.executor({ email: 'alex@clearbit.com' }, authedContext);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('email=alex%40clearbit.com');
+  });
+
+  it('maps camelCase input to snake_case query params', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockPersonResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitEnrichPersonNode.executor(
+      {
+        email: 'alex@clearbit.com',
+        givenName: 'Alex',
+        familyName: 'MacCaw',
+        company: 'Clearbit',
+        companyDomain: 'clearbit.com',
+        linkedIn: 'alexmaccaw',
+        twitter: 'maccaw',
+      },
+      authedContext
+    );
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('given_name=Alex');
+    expect(url).toContain('family_name=MacCaw');
+    expect(url).toContain('company=Clearbit');
+    expect(url).toContain('company_domain=clearbit.com');
+    expect(url).toContain('linkedin=alexmaccaw');
+    expect(url).toContain('twitter=maccaw');
+  });
+
+  it('maps linkedIn input to lowercase linkedin URL param', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockPersonResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitEnrichPersonNode.executor(
+      { email: 'a@b.com', linkedIn: 'foo' },
+      authedContext
+    );
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('linkedin=foo');
+    expect(url).not.toContain('linkedIn=');
+  });
+
+  it('omits optional params when not provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockPersonResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitEnrichPersonNode.executor({ email: 'a@b.com' }, authedContext);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).not.toContain('given_name');
+    expect(url).not.toContain('family_name');
+    expect(url).not.toContain('company=');
+  });
+
+  it('handles nullable response fields', async () => {
+    const sparseResponse = {
+      id: 'xyz',
+      name: { fullName: null, givenName: null, familyName: null },
+      email: null,
+      location: null,
+      employment: {
+        domain: null,
+        name: null,
+        title: null,
+        role: null,
+        seniority: null,
+      },
+      linkedin: null,
+      twitter: null,
+      facebook: null,
+      github: null,
+    };
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(sparseResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichPersonNode.executor(
+      { email: 'a@b.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output?.email).toBeNull();
+    expect(result.output?.location).toBeNull();
+    expect(result.output?.social.linkedin).toBeNull();
+    expect(result.output?.social.twitter).toBeNull();
+    expect(result.output?.social.facebook).toBeNull();
+    expect(result.output?.social.github).toBeNull();
+  });
+
+  it('handles missing social objects in raw response', async () => {
+    const responseWithoutGithub = {
+      id: 'xyz',
+      name: { fullName: 'A', givenName: 'A', familyName: 'B' },
+      email: 'a@b.com',
+      location: 'SF',
+      employment: {
+        domain: 'example.com',
+        name: 'Example',
+        title: 'CEO',
+        role: 'leadership',
+        seniority: 'executive',
+      },
+      linkedin: { handle: 'a' },
+      twitter: { handle: 'a', followers: 100 },
+      // facebook and github absent
+    };
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(responseWithoutGithub));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichPersonNode.executor(
+      { email: 'a@b.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output?.social.facebook).toBeNull();
+    expect(result.output?.social.github).toBeNull();
+  });
+
+  it('returns error on 401 Unauthorized', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('{"error":"invalid token"}', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichPersonNode.executor(
+      { email: 'a@b.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('401');
+  });
+
+  it('returns error on 404 Not Found', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{"error":"not found"}', { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichPersonNode.executor(
+      { email: 'a@b.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('404');
+  });
+
+  it('returns error when response is missing id', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({}));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichPersonNode.executor(
+      { email: 'a@b.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('missing id');
+  });
+
+  it('returns error on network failure', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichPersonNode.executor(
+      { email: 'a@b.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('network down');
+  }, 15000);
+});
+
+// ─── clearbit_enrich_company ──────────────────────────────────────────────────
+
+const mockCompanyResponse = {
+  id: 'c5a6adb1-20c2-4d81-9bf1-dfa00fcc6a46',
+  name: 'Stripe',
+  domain: 'stripe.com',
+  category: {
+    sector: 'Information Technology and Services',
+    industryGroup: 'Software & Services',
+    industry: 'Software',
+    subIndustry: 'Application Software',
+  },
+  metrics: {
+    employees: 1000,
+    employeesRange: '501-1000',
+    raised: 1600000000,
+    marketCap: null,
+    annualRevenue: null,
+    alexaUsRank: 127,
+    alexaGlobalRank: 289,
+  },
+  linkedin: { handle: 'company/stripe' },
+  twitter: { handle: 'stripe', followers: 84000 },
+  facebook: { handle: 'StripeHQ' },
+};
+
+describe('clearbit_enrich_company', () => {
+  it('fails when apiKey is missing', async () => {
+    const result = await clearbitEnrichCompanyNode.executor(
+      { domain: 'stripe.com' },
+      baseContext
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('context.credentials.clearbit.apiKey');
+  });
+
+  it('enriches company by domain', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockCompanyResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichCompanyNode.executor(
+      { domain: 'stripe.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output?.id).toBe('c5a6adb1-20c2-4d81-9bf1-dfa00fcc6a46');
+    expect(result.output?.name).toBe('Stripe');
+    expect(result.output?.domain).toBe('stripe.com');
+  });
+
+  it('targets the company-stream endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockCompanyResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitEnrichCompanyNode.executor({ domain: 'stripe.com' }, authedContext);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('https://company-stream.clearbit.com/v2/companies/find');
+    expect(url).toContain('domain=stripe.com');
+  });
+
+  it('sends Authorization Bearer header', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockCompanyResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitEnrichCompanyNode.executor({ domain: 'stripe.com' }, authedContext);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-clearbit-key');
+  });
+
+  it('maps category fields correctly', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockCompanyResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichCompanyNode.executor(
+      { domain: 'stripe.com' },
+      authedContext
+    );
+
+    expect(result.output?.category).toEqual({
+      sector: 'Information Technology and Services',
+      industryGroup: 'Software & Services',
+      industry: 'Software',
+      subIndustry: 'Application Software',
+    });
+  });
+
+  it('maps metrics fields correctly with nullable fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockCompanyResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichCompanyNode.executor(
+      { domain: 'stripe.com' },
+      authedContext
+    );
+
+    expect(result.output?.metrics).toEqual({
+      employees: 1000,
+      employeesRange: '501-1000',
+      raised: 1600000000,
+      marketCap: null,
+      annualRevenue: null,
+      alexaUsRank: 127,
+      alexaGlobalRank: 289,
+    });
+  });
+
+  it('handles absent social platforms', async () => {
+    const responseNoFacebook = {
+      ...mockCompanyResponse,
+      facebook: undefined,
+    };
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(responseNoFacebook));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichCompanyNode.executor(
+      { domain: 'stripe.com' },
+      authedContext
+    );
+
+    expect(result.output?.social.facebook).toBeNull();
+    expect(result.output?.social.linkedin).not.toBeNull();
+  });
+
+  it('returns error on 401', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('{"error":"invalid token"}', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichCompanyNode.executor(
+      { domain: 'stripe.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('401');
+  });
+
+  it('returns error on 404', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{"error":"not found"}', { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichCompanyNode.executor(
+      { domain: 'nonexistent.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('404');
+  });
+
+  it('returns error when response is missing id', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({}));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichCompanyNode.executor(
+      { domain: 'stripe.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('missing id');
+  });
+
+  it('returns error on network failure', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitEnrichCompanyNode.executor(
+      { domain: 'stripe.com' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('network down');
+  }, 15000);
+});
+
+// ─── clearbit_company_autocomplete ────────────────────────────────────────────
+
+const mockAutocompleteResponse = [
+  { name: 'Stripe', domain: 'stripe.com', logo: 'https://logo.clearbit.com/stripe.com' },
+  { name: 'Stripe, Inc.', domain: 'stripe.co.uk', logo: 'https://logo.clearbit.com/stripe.co.uk' },
+];
+
+describe('clearbit_company_autocomplete', () => {
+  it('fails when apiKey is missing', async () => {
+    const result = await clearbitCompanyAutocompleteNode.executor(
+      { name: 'stripe' },
+      baseContext
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('context.credentials.clearbit.apiKey');
+  });
+
+  it('autocompletes company name', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockAutocompleteResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitCompanyAutocompleteNode.executor(
+      { name: 'stripe' },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output?.companies).toHaveLength(2);
+    expect(result.output?.companies[0]).toEqual({
+      name: 'Stripe',
+      domain: 'stripe.com',
+      logo: 'https://logo.clearbit.com/stripe.com',
+    });
+  });
+
+  it('targets the autocomplete endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockAutocompleteResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitCompanyAutocompleteNode.executor({ name: 'stripe' }, authedContext);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('https://autocomplete.clearbit.com/v1/companies/suggest');
+  });
+
+  it('maps input name to URL query param', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockAutocompleteResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitCompanyAutocompleteNode.executor({ name: 'stripe' }, authedContext);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('query=stripe');
+    expect(url).not.toContain('name=stripe');
+  });
+
+  it('sends Authorization Bearer header', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockAutocompleteResponse));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await clearbitCompanyAutocompleteNode.executor({ name: 'stripe' }, authedContext);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-clearbit-key');
+  });
+
+  it('handles empty autocomplete results', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitCompanyAutocompleteNode.executor(
+      { name: 'xyznonexistent' },
+      authedContext
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output?.companies).toEqual([]);
+  });
+
+  it('returns error on non-OK response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{"error":"bad request"}', { status: 400 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitCompanyAutocompleteNode.executor(
+      { name: 'stripe' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('400');
+  });
+
+  it('returns error when response is not an array', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ error: 'bad shape' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitCompanyAutocompleteNode.executor(
+      { name: 'stripe' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('expected array');
+  });
+
+  it('returns error on network failure', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await clearbitCompanyAutocompleteNode.executor(
+      { name: 'stripe' },
+      authedContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('network down');
+  }, 15000);
+});
+
+// ─── Integration tests ────────────────────────────────────────────────────────
+
+describe('clearbit integration — all nodes fail without credentials', () => {
+  it('all 3 nodes return structured error mentioning clearbit.apiKey', async () => {
+    const person = await clearbitEnrichPersonNode.executor(
+      { email: 'a@b.com' },
+      baseContext
+    );
+    const company = await clearbitEnrichCompanyNode.executor(
+      { domain: 'example.com' },
+      baseContext
+    );
+    const autocomplete = await clearbitCompanyAutocompleteNode.executor(
+      { name: 'x' },
+      baseContext
+    );
+
+    expect(person.success).toBe(false);
+    expect(person.error).toContain('context.credentials.clearbit.apiKey');
+    expect(company.success).toBe(false);
+    expect(company.error).toContain('context.credentials.clearbit.apiKey');
+    expect(autocomplete.success).toBe(false);
+    expect(autocomplete.error).toContain('context.credentials.clearbit.apiKey');
+  });
+});

--- a/packages/nodes/src/integrations/clearbit/clearbit-company-autocomplete.ts
+++ b/packages/nodes/src/integrations/clearbit/clearbit-company-autocomplete.ts
@@ -1,0 +1,94 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry } from '../../utils/http.js';
+import {
+  ClearbitCompanyAutocompleteInputSchema,
+  ClearbitCompanyAutocompleteOutputSchema,
+  type ClearbitCompanyAutocompleteInput,
+  type ClearbitCompanyAutocompleteOutput,
+} from './schemas.js';
+
+export {
+  ClearbitCompanyAutocompleteInputSchema,
+  ClearbitCompanyAutocompleteOutputSchema,
+  type ClearbitCompanyAutocompleteInput,
+  type ClearbitCompanyAutocompleteOutput,
+} from './schemas.js';
+
+const AUTOCOMPLETE_URL = 'https://autocomplete.clearbit.com/v1/companies/suggest';
+
+interface ClearbitAutocompleteEntry {
+  name?: string;
+  domain?: string;
+  logo?: string;
+}
+
+export const clearbitCompanyAutocompleteNode = defineNode({
+  type: 'clearbit_company_autocomplete',
+  name: 'Clearbit Company Autocomplete',
+  description:
+    'Autocomplete company names via Clearbit. Returns matching companies with name, domain, and logo.',
+  category: 'integration',
+  inputSchema: ClearbitCompanyAutocompleteInputSchema,
+  outputSchema: ClearbitCompanyAutocompleteOutputSchema,
+  estimatedDuration: 3,
+  capabilities: {
+    supportsRerun: true,
+  },
+  executor: async (input: ClearbitCompanyAutocompleteInput, context) => {
+    try {
+      const apiKey = context.credentials?.clearbit?.apiKey;
+      if (!apiKey) {
+        return {
+          success: false,
+          error:
+            'Clearbit API key not configured. Please provide context.credentials.clearbit.apiKey.',
+        };
+      }
+
+      const params = new URLSearchParams({ query: input.name });
+
+      const response = await fetchWithRetry(
+        `${AUTOCOMPLETE_URL}?${params.toString()}`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return {
+          success: false,
+          error: `Clearbit API error: ${response.status} - ${errorText}`,
+        };
+      }
+
+      const raw = (await response.json()) as unknown;
+
+      if (!Array.isArray(raw)) {
+        return {
+          success: false,
+          error: 'Clearbit autocomplete returned an invalid response (expected array).',
+        };
+      }
+
+      const companies = (raw as ClearbitAutocompleteEntry[]).map((entry) => ({
+        name: entry.name ?? '',
+        domain: entry.domain ?? '',
+        logo: entry.logo ?? '',
+      }));
+
+      const output: ClearbitCompanyAutocompleteOutput = { companies };
+
+      return { success: true, output };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to autocomplete company',
+      };
+    }
+  },
+});

--- a/packages/nodes/src/integrations/clearbit/clearbit-enrich-company.ts
+++ b/packages/nodes/src/integrations/clearbit/clearbit-enrich-company.ts
@@ -1,0 +1,135 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry } from '../../utils/http.js';
+import {
+  ClearbitEnrichCompanyInputSchema,
+  ClearbitEnrichCompanyOutputSchema,
+  type ClearbitEnrichCompanyInput,
+  type ClearbitEnrichCompanyOutput,
+} from './schemas.js';
+
+export {
+  ClearbitEnrichCompanyInputSchema,
+  ClearbitEnrichCompanyOutputSchema,
+  type ClearbitEnrichCompanyInput,
+  type ClearbitEnrichCompanyOutput,
+} from './schemas.js';
+
+const COMPANY_ENRICH_URL = 'https://company-stream.clearbit.com/v2/companies/find';
+
+interface ClearbitCompanyResponse {
+  id?: string;
+  name?: string | null;
+  domain?: string | null;
+  category?: {
+    sector?: string | null;
+    industryGroup?: string | null;
+    industry?: string | null;
+    subIndustry?: string | null;
+  } | null;
+  metrics?: {
+    employees?: number | null;
+    employeesRange?: string | null;
+    raised?: number | null;
+    marketCap?: number | null;
+    annualRevenue?: number | null;
+    alexaUsRank?: number | null;
+    alexaGlobalRank?: number | null;
+  } | null;
+  linkedin?: { handle?: string | null } | null;
+  twitter?: { handle?: string | null; followers?: number | null } | null;
+  facebook?: { handle?: string | null } | null;
+}
+
+export const clearbitEnrichCompanyNode = defineNode({
+  type: 'clearbit_enrich_company',
+  name: 'Clearbit Enrich Company',
+  description:
+    'Enrich a company by domain using Clearbit. Returns name, category, metrics, and social profiles.',
+  category: 'integration',
+  inputSchema: ClearbitEnrichCompanyInputSchema,
+  outputSchema: ClearbitEnrichCompanyOutputSchema,
+  estimatedDuration: 5,
+  capabilities: {
+    supportsRerun: true,
+  },
+  executor: async (input: ClearbitEnrichCompanyInput, context) => {
+    try {
+      const apiKey = context.credentials?.clearbit?.apiKey;
+      if (!apiKey) {
+        return {
+          success: false,
+          error:
+            'Clearbit API key not configured. Please provide context.credentials.clearbit.apiKey.',
+        };
+      }
+
+      const params = new URLSearchParams({ domain: input.domain });
+
+      const response = await fetchWithRetry(
+        `${COMPANY_ENRICH_URL}?${params.toString()}`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return {
+          success: false,
+          error: `Clearbit API error: ${response.status} - ${errorText}`,
+        };
+      }
+
+      const raw = (await response.json()) as ClearbitCompanyResponse;
+
+      if (typeof raw?.id !== 'string') {
+        return {
+          success: false,
+          error: 'Clearbit API returned an invalid company response (missing id).',
+        };
+      }
+
+      const output: ClearbitEnrichCompanyOutput = {
+        id: raw.id,
+        name: raw.name ?? null,
+        domain: raw.domain ?? null,
+        category: {
+          sector: raw.category?.sector ?? null,
+          industryGroup: raw.category?.industryGroup ?? null,
+          industry: raw.category?.industry ?? null,
+          subIndustry: raw.category?.subIndustry ?? null,
+        },
+        metrics: {
+          employees: raw.metrics?.employees ?? null,
+          employeesRange: raw.metrics?.employeesRange ?? null,
+          raised: raw.metrics?.raised ?? null,
+          marketCap: raw.metrics?.marketCap ?? null,
+          annualRevenue: raw.metrics?.annualRevenue ?? null,
+          alexaUsRank: raw.metrics?.alexaUsRank ?? null,
+          alexaGlobalRank: raw.metrics?.alexaGlobalRank ?? null,
+        },
+        social: {
+          linkedin: raw.linkedin ? { handle: raw.linkedin.handle ?? null } : null,
+          twitter: raw.twitter
+            ? {
+                handle: raw.twitter.handle ?? null,
+                followers: raw.twitter.followers ?? null,
+              }
+            : null,
+          facebook: raw.facebook ? { handle: raw.facebook.handle ?? null } : null,
+        },
+      };
+
+      return { success: true, output };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to enrich company',
+      };
+    }
+  },
+});

--- a/packages/nodes/src/integrations/clearbit/clearbit-enrich-person.ts
+++ b/packages/nodes/src/integrations/clearbit/clearbit-enrich-person.ts
@@ -1,0 +1,137 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry } from '../../utils/http.js';
+import {
+  ClearbitEnrichPersonInputSchema,
+  ClearbitEnrichPersonOutputSchema,
+  type ClearbitEnrichPersonInput,
+  type ClearbitEnrichPersonOutput,
+} from './schemas.js';
+
+export {
+  ClearbitEnrichPersonInputSchema,
+  ClearbitEnrichPersonOutputSchema,
+  type ClearbitEnrichPersonInput,
+  type ClearbitEnrichPersonOutput,
+} from './schemas.js';
+
+const PERSON_ENRICH_URL = 'https://person-stream.clearbit.com/v2/people/find';
+
+interface ClearbitPersonResponse {
+  id?: string;
+  name?: {
+    fullName?: string | null;
+    givenName?: string | null;
+    familyName?: string | null;
+  } | null;
+  email?: string | null;
+  location?: string | null;
+  employment?: {
+    domain?: string | null;
+    name?: string | null;
+    title?: string | null;
+    role?: string | null;
+    seniority?: string | null;
+  } | null;
+  linkedin?: { handle?: string | null } | null;
+  twitter?: { handle?: string | null; followers?: number | null } | null;
+  facebook?: { handle?: string | null } | null;
+  github?: { handle?: string | null } | null;
+}
+
+export const clearbitEnrichPersonNode = defineNode({
+  type: 'clearbit_enrich_person',
+  name: 'Clearbit Enrich Person',
+  description:
+    'Enrich a person by email using Clearbit. Returns name, location, employment, and social profiles.',
+  category: 'integration',
+  inputSchema: ClearbitEnrichPersonInputSchema,
+  outputSchema: ClearbitEnrichPersonOutputSchema,
+  estimatedDuration: 5,
+  capabilities: {
+    supportsRerun: true,
+  },
+  executor: async (input: ClearbitEnrichPersonInput, context) => {
+    try {
+      const apiKey = context.credentials?.clearbit?.apiKey;
+      if (!apiKey) {
+        return {
+          success: false,
+          error:
+            'Clearbit API key not configured. Please provide context.credentials.clearbit.apiKey.',
+        };
+      }
+
+      const params = new URLSearchParams({ email: input.email });
+      if (input.givenName) params.set('given_name', input.givenName);
+      if (input.familyName) params.set('family_name', input.familyName);
+      if (input.company) params.set('company', input.company);
+      if (input.companyDomain) params.set('company_domain', input.companyDomain);
+      if (input.linkedIn) params.set('linkedin', input.linkedIn);
+      if (input.twitter) params.set('twitter', input.twitter);
+
+      const response = await fetchWithRetry(
+        `${PERSON_ENRICH_URL}?${params.toString()}`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+        { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return {
+          success: false,
+          error: `Clearbit API error: ${response.status} - ${errorText}`,
+        };
+      }
+
+      const raw = (await response.json()) as ClearbitPersonResponse;
+
+      if (typeof raw?.id !== 'string') {
+        return {
+          success: false,
+          error: 'Clearbit API returned an invalid person response (missing id).',
+        };
+      }
+
+      const output: ClearbitEnrichPersonOutput = {
+        id: raw.id,
+        name: {
+          fullName: raw.name?.fullName ?? null,
+          givenName: raw.name?.givenName ?? null,
+          familyName: raw.name?.familyName ?? null,
+        },
+        email: raw.email ?? null,
+        location: raw.location ?? null,
+        employment: {
+          domain: raw.employment?.domain ?? null,
+          name: raw.employment?.name ?? null,
+          title: raw.employment?.title ?? null,
+          role: raw.employment?.role ?? null,
+          seniority: raw.employment?.seniority ?? null,
+        },
+        social: {
+          linkedin: raw.linkedin ? { handle: raw.linkedin.handle ?? null } : null,
+          twitter: raw.twitter
+            ? {
+                handle: raw.twitter.handle ?? null,
+                followers: raw.twitter.followers ?? null,
+              }
+            : null,
+          facebook: raw.facebook ? { handle: raw.facebook.handle ?? null } : null,
+          github: raw.github ? { handle: raw.github.handle ?? null } : null,
+        },
+      };
+
+      return { success: true, output };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to enrich person',
+      };
+    }
+  },
+});

--- a/packages/nodes/src/integrations/clearbit/credentials.ts
+++ b/packages/nodes/src/integrations/clearbit/credentials.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { defineApiKeyCredential } from '@jam-nodes/core';
+
+export const clearbitCredential = defineApiKeyCredential({
+  name: 'clearbit',
+  displayName: 'Clearbit API',
+  documentationUrl: 'https://clearbit.com/docs',
+  schema: z.object({
+    apiKey: z.string(),
+  }),
+  authenticate: {
+    type: 'header',
+    properties: {
+      Authorization: 'Bearer {{apiKey}}',
+    },
+  },
+});

--- a/packages/nodes/src/integrations/clearbit/index.ts
+++ b/packages/nodes/src/integrations/clearbit/index.ts
@@ -1,0 +1,25 @@
+export { clearbitCredential } from './credentials.js';
+
+export {
+  clearbitEnrichPersonNode,
+  ClearbitEnrichPersonInputSchema,
+  ClearbitEnrichPersonOutputSchema,
+  type ClearbitEnrichPersonInput,
+  type ClearbitEnrichPersonOutput,
+} from './clearbit-enrich-person.js';
+
+export {
+  clearbitEnrichCompanyNode,
+  ClearbitEnrichCompanyInputSchema,
+  ClearbitEnrichCompanyOutputSchema,
+  type ClearbitEnrichCompanyInput,
+  type ClearbitEnrichCompanyOutput,
+} from './clearbit-enrich-company.js';
+
+export {
+  clearbitCompanyAutocompleteNode,
+  ClearbitCompanyAutocompleteInputSchema,
+  ClearbitCompanyAutocompleteOutputSchema,
+  type ClearbitCompanyAutocompleteInput,
+  type ClearbitCompanyAutocompleteOutput,
+} from './clearbit-company-autocomplete.js';

--- a/packages/nodes/src/integrations/clearbit/schemas.ts
+++ b/packages/nodes/src/integrations/clearbit/schemas.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+
+// ─── Enrich Person ────────────────────────────────────────────────────────────
+
+export const ClearbitEnrichPersonInputSchema = z.object({
+  email: z.string().min(1, 'Email is required'),
+  givenName: z.string().optional(),
+  familyName: z.string().optional(),
+  company: z.string().optional(),
+  companyDomain: z.string().optional(),
+  linkedIn: z.string().optional(),
+  twitter: z.string().optional(),
+});
+
+const PersonNameSchema = z.object({
+  fullName: z.string().nullable(),
+  givenName: z.string().nullable(),
+  familyName: z.string().nullable(),
+});
+
+const PersonEmploymentSchema = z.object({
+  domain: z.string().nullable(),
+  name: z.string().nullable(),
+  title: z.string().nullable(),
+  role: z.string().nullable(),
+  seniority: z.string().nullable(),
+});
+
+const PersonSocialSchema = z.object({
+  linkedin: z.object({ handle: z.string().nullable() }).nullable(),
+  twitter: z
+    .object({ handle: z.string().nullable(), followers: z.number().nullable() })
+    .nullable(),
+  facebook: z.object({ handle: z.string().nullable() }).nullable(),
+  github: z.object({ handle: z.string().nullable() }).nullable(),
+});
+
+export const ClearbitEnrichPersonOutputSchema = z.object({
+  id: z.string(),
+  name: PersonNameSchema,
+  email: z.string().nullable(),
+  location: z.string().nullable(),
+  employment: PersonEmploymentSchema,
+  social: PersonSocialSchema,
+});
+
+// ─── Enrich Company ───────────────────────────────────────────────────────────
+
+export const ClearbitEnrichCompanyInputSchema = z.object({
+  domain: z.string().min(1, 'Domain is required'),
+});
+
+const CompanyCategorySchema = z.object({
+  sector: z.string().nullable(),
+  industryGroup: z.string().nullable(),
+  industry: z.string().nullable(),
+  subIndustry: z.string().nullable(),
+});
+
+const CompanyMetricsSchema = z.object({
+  employees: z.number().nullable(),
+  employeesRange: z.string().nullable(),
+  raised: z.number().nullable(),
+  marketCap: z.number().nullable(),
+  annualRevenue: z.number().nullable(),
+  alexaUsRank: z.number().nullable(),
+  alexaGlobalRank: z.number().nullable(),
+});
+
+const CompanySocialSchema = z.object({
+  linkedin: z.object({ handle: z.string().nullable() }).nullable(),
+  twitter: z
+    .object({ handle: z.string().nullable(), followers: z.number().nullable() })
+    .nullable(),
+  facebook: z.object({ handle: z.string().nullable() }).nullable(),
+});
+
+export const ClearbitEnrichCompanyOutputSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  domain: z.string().nullable(),
+  category: CompanyCategorySchema,
+  metrics: CompanyMetricsSchema,
+  social: CompanySocialSchema,
+});
+
+// ─── Company Autocomplete ─────────────────────────────────────────────────────
+
+export const ClearbitCompanyAutocompleteInputSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+});
+
+export const ClearbitCompanyAutocompleteOutputSchema = z.object({
+  companies: z.array(
+    z.object({
+      name: z.string(),
+      domain: z.string(),
+      logo: z.string(),
+    })
+  ),
+});
+
+// ─── Inferred types ───────────────────────────────────────────────────────────
+
+export type ClearbitEnrichPersonInput = z.infer<typeof ClearbitEnrichPersonInputSchema>;
+export type ClearbitEnrichPersonOutput = z.infer<typeof ClearbitEnrichPersonOutputSchema>;
+
+export type ClearbitEnrichCompanyInput = z.infer<typeof ClearbitEnrichCompanyInputSchema>;
+export type ClearbitEnrichCompanyOutput = z.infer<typeof ClearbitEnrichCompanyOutputSchema>;
+
+export type ClearbitCompanyAutocompleteInput = z.infer<
+  typeof ClearbitCompanyAutocompleteInputSchema
+>;
+export type ClearbitCompanyAutocompleteOutput = z.infer<
+  typeof ClearbitCompanyAutocompleteOutputSchema
+>;

--- a/packages/nodes/src/integrations/index.ts
+++ b/packages/nodes/src/integrations/index.ts
@@ -275,3 +275,23 @@ export {
   type SlackSearchMatch,
   slackCredential,
 } from './slack/index.js'
+
+// Clearbit integrations
+export {
+  clearbitCredential,
+  clearbitEnrichPersonNode,
+  ClearbitEnrichPersonInputSchema,
+  ClearbitEnrichPersonOutputSchema,
+  type ClearbitEnrichPersonInput,
+  type ClearbitEnrichPersonOutput,
+  clearbitEnrichCompanyNode,
+  ClearbitEnrichCompanyInputSchema,
+  ClearbitEnrichCompanyOutputSchema,
+  type ClearbitEnrichCompanyInput,
+  type ClearbitEnrichCompanyOutput,
+  clearbitCompanyAutocompleteNode,
+  ClearbitCompanyAutocompleteInputSchema,
+  ClearbitCompanyAutocompleteOutputSchema,
+  type ClearbitCompanyAutocompleteInput,
+  type ClearbitCompanyAutocompleteOutput,
+} from './clearbit/index.js'


### PR DESCRIPTION
## Summary

Adds a Clearbit API integration covering the three operations specified in issue #15: person enrichment, company enrichment, and company autocomplete. Resolves #15.

## Operations

| Node | Endpoint | Purpose |
|---|---|---|
| `clearbitEnrichPerson` | `GET https://person-stream.clearbit.com/v2/people/find` | Enrich a person by email (optional: given/family name, company, company domain, linkedIn, twitter) |
| `clearbitEnrichCompany` | `GET https://company-stream.clearbit.com/v2/companies/find` | Enrich a company by domain |
| `clearbitCompanyAutocomplete` | `GET https://autocomplete.clearbit.com/v1/companies/suggest` | Suggest companies from a partial name |

## Credential

Single API-key credential (`clearbit`) authenticating via `Authorization: Bearer {{apiKey}}` header, defined through `defineApiKeyCredential` from `@jam-nodes/core`. Matches the shape declared in issue #15 exactly.

## Implementation notes

- **Streaming endpoints.** Uses Clearbit's `person-stream` / `company-stream` subdomains instead of the non-streaming alternatives, because the non-streaming endpoints return `202 + webhook callback` (unsuitable for synchronous workflow execution). Matches the n8n reference implementation.
- **CamelCase → snake_case URL mapping.** Input fields (`givenName`, `familyName`, `companyDomain`) are mapped to Clearbit's snake_case query params (`given_name`, `family_name`, `company_domain`). The `linkedIn` field specifically maps to lowercase `linkedin` to match Clearbit's URL convention.
- **Autocomplete `name` → `query`.** The issue's input field is `name` but Clearbit's URL param is `query`; mapped at request-build time.
- **Response mapping.** Clearbit returns richer objects than issue #15 asks for; output schemas extract only the fields the issue specifies. Nullable fields (`location`, `employment.title`, `social.github`, etc.) are handled with `?? null` and tested explicitly against sparse responses.
- **File per operation.** `clearbit-enrich-person.ts`, `clearbit-enrich-company.ts`, `clearbit-company-autocomplete.ts`, each self-contained — follows the apify / devto precedent.
- **HTTP layer.** Uses the shared `fetchWithRetry` utility (default: 3 retries, 1s initial backoff, 30s timeout). No retry/cache/timeout configuration inside node bodies — nodes stay pure per the architectural rule in `CLAUDE.md`.
- **Error handling.** All three nodes return `{ success: false, error }` on missing credentials, non-OK responses, malformed responses (missing `id`), and network failures. They never throw.

## Files changed

- `packages/core/src/types/node.ts` — extend `NodeCredentials` with `clearbit?: { apiKey: string }`
- `packages/nodes/src/integrations/clearbit/credentials.ts` — new, `clearbitCredential`
- `packages/nodes/src/integrations/clearbit/schemas.ts` — new, 6 Zod schemas + 6 inferred types
- `packages/nodes/src/integrations/clearbit/clearbit-enrich-person.ts` — new node
- `packages/nodes/src/integrations/clearbit/clearbit-enrich-company.ts` — new node
- `packages/nodes/src/integrations/clearbit/clearbit-company-autocomplete.ts` — new node
- `packages/nodes/src/integrations/clearbit/index.ts` — new barrel
- `packages/nodes/src/integrations/clearbit/__tests__/clearbit.test.ts` — new, 50 tests
- `packages/nodes/src/integrations/index.ts` — re-export clearbit
- `packages/nodes/src/index.ts` — add value + type exports, append to `builtInNodes[]`

## Test coverage (50 tests, all passing)

- **Credential** (5): name/type/displayName, header Bearer authentication, documentation URL, schema accepts `{apiKey}`, schema rejects `{}`
- **Schemas** (10): required-field validation + empty-string rejection + optional-field acceptance for all 3 operations
- **`clearbit_enrich_person`** (13): missing API key, full happy path, endpoint URL, Bearer header, email query param, camelCase→snake_case mapping, `linkedIn`→`linkedin` lowercase, omitting absent optionals, nullable response fields, missing nested social objects, 401, 404, missing-id guard, network failure
- **`clearbit_enrich_company`** (11): missing API key, happy path, endpoint URL, Bearer header, category mapping, metrics mapping with nulls, absent social platforms, 401, 404, missing-id guard, network failure
- **`clearbit_company_autocomplete`** (8): missing API key, happy path, endpoint URL, `name`→`query` param mapping, Bearer header, empty results, non-OK response, malformed (non-array) response, network failure
- **Integration** (1): all 3 nodes return structured `context.credentials.clearbit.apiKey` error when credentials are absent

## Verification

```
$ npm --workspace=@jam-nodes/nodes test
Test Files  10 passed (10)
     Tests  245 passed (245)
  Duration  10.72s
```

- Full suite: **245/245 passing**, zero regressions vs `main` baseline
- Clearbit test file alone: 50/50 passing
- `tsc --noEmit` scoped to clearbit files, `integrations/index.ts`, `nodes/src/index.ts`, `types/node.ts`: zero errors (pre-existing unrelated typecheck errors in `apify/`, `google-sheets/`, `slack/` are untouched)

## Acceptance criteria (from issue #15)

- [x] Credential definition
- [x] All 3 operations
- [x] Zod schemas
- [x] Unit tests

Closes #15