### PR TITLE
add dropcontact integration - GDPR-compliant B2B enrichment

### DIFF
--- a/packages/core/src/types/node.ts
+++ b/packages/core/src/types/node.ts
@@ -84,6 +84,10 @@ export interface NodeCredentials {
     refreshToken: string
     expiresAt: number
   }
+  /** Dropcontact API credentials (GDPR-compliant B2B enrichment) */
+  dropcontact?: {
+    apiKey: string
+  }
 }
 
 /**

--- a/packages/nodes/src/index.ts
+++ b/packages/nodes/src/index.ts
@@ -196,6 +196,11 @@ export {
   readOutputSchema,
   updateInputSchema,
   updateOutputSchema,
+  // Dropcontact
+  dropcontactEnrichNode,
+  DropcontactEnrichInputSchema,
+  DropcontactEnrichOutputSchema,
+  dropcontactCredential,
 } from './integrations/index.js'
 
 export type {
@@ -276,6 +281,9 @@ export type {
   ReadOutput,
   UpdateInput,
   UpdateOutput,
+  // Dropcontact
+  DropcontactEnrichInput,
+  DropcontactEnrichOutput,
 } from './integrations/index.js'
 
 // AI nodes
@@ -348,6 +356,7 @@ import {
   googleSheetsClearNode,
   googleSheetsReadNode,
   googleSheetsUpdateNode,
+  dropcontactEnrichNode,
 } from './integrations/index.js'
 import {
   socialKeywordGeneratorNode,
@@ -407,6 +416,8 @@ export const builtInNodes = [
   googleSheetsClearNode,
   googleSheetsReadNode,
   googleSheetsUpdateNode,
+  // Dropcontact
+  dropcontactEnrichNode,
   // AI
   socialKeywordGeneratorNode,
   draftEmailsNode,

--- a/packages/nodes/src/integrations/dropcontact/__tests__/dropcontact.test.ts
+++ b/packages/nodes/src/integrations/dropcontact/__tests__/dropcontact.test.ts
@@ -1,0 +1,817 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { executeNode } from '@jam-nodes/core';
+import {
+  dropcontactCredential,
+  dropcontactEnrichNode,
+  DropcontactEnrichInputSchema,
+  DropcontactEnrichOutputSchema,
+} from '../index.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const makeContext = (credentials?: Record<string, unknown>) => ({
+  userId: 'u1',
+  workflowExecutionId: 'wf1',
+  variables: {},
+  resolveNestedPath: () => undefined,
+  credentials,
+});
+
+const jsonResponse = (body: unknown, init: ResponseInit = { status: 200 }) =>
+  new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+
+const validInput = {
+  email: 'jane@example.com',
+  language: 'en' as const,
+  siren: false,
+  timeout: 120,
+};
+
+// =============================================================================
+// Credential
+// =============================================================================
+
+describe('dropcontact credential', () => {
+  it('has correct metadata', () => {
+    expect(dropcontactCredential.name).toBe('dropcontact');
+    expect(dropcontactCredential.type).toBe('apiKey');
+    expect(dropcontactCredential.authenticate.type).toBe('header');
+    expect(dropcontactCredential.authenticate.properties['X-Access-Token']).toBe('{{apiKey}}');
+  });
+
+  it('schema accepts valid apiKey', () => {
+    const result = dropcontactCredential.schema.safeParse({ apiKey: 'abc123' });
+    expect(result.success).toBe(true);
+  });
+
+  it('schema rejects empty apiKey', () => {
+    const result = dropcontactCredential.schema.safeParse({ apiKey: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('schema rejects missing apiKey', () => {
+    const result = dropcontactCredential.schema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// Schemas
+// =============================================================================
+
+describe('dropcontact schemas', () => {
+  it('input: accepts all fields', () => {
+    const result = DropcontactEnrichInputSchema.safeParse({
+      email: 'jane@example.com',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      fullName: 'Jane Doe',
+      company: 'Acme',
+      website: 'https://acme.com',
+      linkedinUrl: 'https://linkedin.com/in/jane',
+      phone: '+1-555-0100',
+      language: 'fr',
+      siren: true,
+      timeout: 60,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('input: accepts empty object and applies defaults', () => {
+    const result = DropcontactEnrichInputSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.language).toBe('en');
+      expect(result.data.siren).toBe(false);
+      expect(result.data.timeout).toBe(120);
+    }
+  });
+
+  it('input: rejects invalid email', () => {
+    const result = DropcontactEnrichInputSchema.safeParse({ email: 'not-an-email' });
+    expect(result.success).toBe(false);
+  });
+
+  it('input: rejects empty email string', () => {
+    const result = DropcontactEnrichInputSchema.safeParse({ email: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('input: rejects invalid language', () => {
+    const result = DropcontactEnrichInputSchema.safeParse({ language: 'de' });
+    expect(result.success).toBe(false);
+  });
+
+  it('input: rejects negative timeout', () => {
+    const result = DropcontactEnrichInputSchema.safeParse({ timeout: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('input: rejects zero timeout', () => {
+    const result = DropcontactEnrichInputSchema.safeParse({ timeout: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it('output: accepts nulls for enriched fields with non-null control fields', () => {
+    const result = DropcontactEnrichOutputSchema.safeParse({
+      requestId: 'req-1',
+      success: true,
+      creditsLeft: null,
+      email: null,
+      firstName: null,
+      lastName: null,
+      fullName: null,
+      civility: null,
+      company: null,
+      website: null,
+      linkedin: null,
+      phone: null,
+      mobilePhone: null,
+      siren: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('output: rejects missing requestId', () => {
+    const result = DropcontactEnrichOutputSchema.safeParse({
+      success: true,
+      creditsLeft: null,
+      email: null,
+      firstName: null,
+      lastName: null,
+      fullName: null,
+      civility: null,
+      company: null,
+      website: null,
+      linkedin: null,
+      phone: null,
+      mobilePhone: null,
+      siren: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('output: rejects null requestId', () => {
+    const result = DropcontactEnrichOutputSchema.safeParse({
+      requestId: null,
+      success: true,
+      creditsLeft: null,
+      email: null,
+      firstName: null,
+      lastName: null,
+      fullName: null,
+      civility: null,
+      company: null,
+      website: null,
+      linkedin: null,
+      phone: null,
+      mobilePhone: null,
+      siren: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('output: rejects missing success field', () => {
+    const result = DropcontactEnrichOutputSchema.safeParse({
+      requestId: 'req-1',
+      creditsLeft: null,
+      email: null,
+      firstName: null,
+      lastName: null,
+      fullName: null,
+      civility: null,
+      company: null,
+      website: null,
+      linkedin: null,
+      phone: null,
+      mobilePhone: null,
+      siren: null,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// dropcontactEnrichNode
+// =============================================================================
+
+describe('dropcontactEnrichNode', () => {
+  it('has correct metadata', () => {
+    expect(dropcontactEnrichNode.type).toBe('dropcontact_enrich');
+    expect(dropcontactEnrichNode.category).toBe('integration');
+    expect(dropcontactEnrichNode.estimatedDuration).toBe(30);
+  });
+
+  // ─── Credential handling ───────────────────────────────────────────────────
+
+  it('returns failure when credentials object is empty', async () => {
+    const result = await dropcontactEnrichNode.executor(validInput, makeContext({}));
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/api key|apiKey/i);
+  });
+
+  it('returns failure when credentials.dropcontact is missing', async () => {
+    const result = await dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ apollo: { apiKey: 'x' } })
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/dropcontact/i);
+  });
+
+  it('returns failure when credentials.dropcontact.apiKey is empty string', async () => {
+    const result = await dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: '' } })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  // ─── POST submission ───────────────────────────────────────────────────────
+
+  it('POSTs to /batch with X-Access-Token header and JSON body', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1', credits_left: 100 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: [{ email: 'jane@example.com', first_name: 'Jane' }],
+          credits_left: 99,
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      { ...validInput, firstName: 'Jane', company: 'Acme' },
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.dropcontact.io/batch');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-Access-Token']).toBe('test-key');
+    expect(headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(init.body as string) as {
+      data: Array<Record<string, unknown>>;
+      siren: boolean;
+      language: string;
+    };
+    expect(body.siren).toBe(false);
+    expect(body.language).toBe('en');
+    expect(body.data[0]?.['email']).toBe('jane@example.com');
+    expect(body.data[0]?.['first_name']).toBe('Jane');
+    expect(body.data[0]?.['company']).toBe('Acme');
+  });
+
+  it('POST body only contains user-supplied fields', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValueOnce(
+        jsonResponse({ success: true, data: [{ email: 'jane@example.com' }] })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      { email: 'jane@example.com', language: 'en', siren: false, timeout: 120 },
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { data: Array<Record<string, unknown>> };
+    const contact = body.data[0] ?? {};
+    expect(contact['email']).toBe('jane@example.com');
+    expect('first_name' in contact).toBe(false);
+    expect('last_name' in contact).toBe(false);
+    expect('company' in contact).toBe(false);
+    expect('phone' in contact).toBe(false);
+  });
+
+  // ─── Polling behavior ──────────────────────────────────────────────────────
+
+  it('polls /batch/{requestId} until data is present', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-abc' }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: [] }))
+      .mockResolvedValueOnce(jsonResponse({ success: true })) // data missing
+      .mockResolvedValueOnce(
+        jsonResponse({ success: true, data: [{ first_name: 'Jane' }], credits_left: 50 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(result.output?.firstName).toBe('Jane');
+    expect(result.output?.creditsLeft).toBe(50);
+  });
+
+  it('poll does NOT terminate on success:true with missing data (regression)', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-abc' }))
+      .mockResolvedValueOnce(jsonResponse({ success: true })) // no data field
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: [] })) // empty data
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: [{ email: 'jane@example.com', first_name: 'Jane' }],
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(result.output?.email).toBe('jane@example.com');
+    expect(result.output?.firstName).toBe('Jane');
+  });
+
+  it('poll terminates on success:false from GET and surfaces reason', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-abc' }))
+      .mockResolvedValueOnce(jsonResponse({ success: false, reason: 'Invalid data' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid data');
+  });
+
+  it('returns failure when POST returns success:false (credit exhaustion)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: false, reason: 'Insufficient credits' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Insufficient credits');
+  });
+
+  it('polling URL is /batch/{requestId} with api_key query param (URL-encoded)', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req abc/1' }))
+      .mockResolvedValueOnce(
+        jsonResponse({ success: true, data: [{ first_name: 'Jane' }] })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test key=!' } })
+    );
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const [pollUrl, pollInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(pollInit.method).toBe('GET');
+    // request_id spaces and slashes must be URL-encoded
+    expect(pollUrl).toContain('/batch/req%20abc%2F1');
+    // api_key spaces and `=` must be URL-encoded; `!` is unreserved so it stays literal
+    expect(pollUrl).toContain('api_key=test%20key%3D!');
+  });
+
+  // ─── Output mapping ────────────────────────────────────────────────────────
+
+  it('maps snake_case API fields to camelCase output', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          credits_left: 42,
+          data: [
+            {
+              email: 'jane@example.com',
+              first_name: 'Jane',
+              last_name: 'Doe',
+              full_name: 'Jane Doe',
+              mobile_phone: '+33 6 12',
+              civility: 'Mrs',
+              company: 'Acme',
+              linkedin: 'https://linkedin.com/in/jane',
+              siren: '123456789',
+            },
+          ],
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.output?.requestId).toBe('req-1');
+    expect(result.output?.success).toBe(true);
+    expect(result.output?.creditsLeft).toBe(42);
+    expect(result.output?.email).toBe('jane@example.com');
+    expect(result.output?.firstName).toBe('Jane');
+    expect(result.output?.lastName).toBe('Doe');
+    expect(result.output?.fullName).toBe('Jane Doe');
+    expect(result.output?.mobilePhone).toBe('+33 6 12');
+    expect(result.output?.civility).toBe('Mrs');
+    expect(result.output?.company).toBe('Acme');
+    expect(result.output?.linkedin).toBe('https://linkedin.com/in/jane');
+    expect(result.output?.siren).toBe('123456789');
+  });
+
+  it('missing fields in API data[0] become null, not undefined', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValueOnce(
+        jsonResponse({ success: true, data: [{ email: 'jane@example.com' }] })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.output?.email).toBe('jane@example.com');
+    expect(result.output?.firstName).toBeNull();
+    expect(result.output?.lastName).toBeNull();
+    expect(result.output?.phone).toBeNull();
+    expect(result.output?.mobilePhone).toBeNull();
+    expect(result.output?.company).toBeNull();
+  });
+
+  it('extra undocumented fields in data[0] are stripped from output', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: [{ first_name: 'Jane', unexpected_field: 'xyz', another: 123 }],
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBeDefined();
+    expect(result.output && 'unexpected_field' in result.output).toBe(false);
+    expect(result.output && 'another' in result.output).toBe(false);
+  });
+
+  it('empty data array is NOT a terminal success', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({ success: true, data: [{ first_name: 'Jane' }] })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result.output?.firstName).toBe('Jane');
+  });
+
+  it('data[0] with all null fields is still a terminal success', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: [{ first_name: null, last_name: null, email: null, phone: null }],
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.output?.firstName).toBeNull();
+    expect(result.output?.lastName).toBeNull();
+    expect(result.output?.email).toBeNull();
+    expect(result.output?.phone).toBeNull();
+  });
+
+  // ─── Failure paths ─────────────────────────────────────────────────────────
+
+  it('returns failure on polling timeout', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValue(jsonResponse({ success: true })); // always pending
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      { ...validInput, timeout: 1 },
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/timed out/i);
+  });
+
+  it('returns failure on 401 from POST', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/401|auth/i);
+  });
+
+  it('returns failure on 5xx from POST after retries exhausted', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('Server error', { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/500|server/i);
+  });
+
+  it('network error on second poll is propagated', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: [] }))
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockRejectedValueOnce(new Error('ECONNRESET'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('ECONNRESET');
+  });
+
+  it('429 during polling is retried by fetchWithRetry', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValueOnce(
+        new Response('rate limited', {
+          status: 429,
+          headers: { 'retry-after': '0' },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ success: true, data: [{ first_name: 'Jane' }] })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.output?.firstName).toBe('Jane');
+  });
+
+  // ─── Extra coverage (from /review feedback) ────────────────────────────────
+
+  it('returns failure when submit returns 2xx but missing request_id', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true })); // no request_id
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/request_id/i);
+  });
+
+  it('maps non-string API field values to null', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: [
+            {
+              first_name: 'Jane',
+              last_name: 42, // number — should become null
+              phone: ['+1', '+2'], // array — should become null
+              company: { name: 'Acme' }, // object — should become null
+              email: true, // boolean — should become null
+            },
+          ],
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.output?.firstName).toBe('Jane');
+    expect(result.output?.lastName).toBeNull();
+    expect(result.output?.phone).toBeNull();
+    expect(result.output?.company).toBeNull();
+    expect(result.output?.email).toBeNull();
+  });
+
+  it('preserves creditsLeft from submit response when poll response omits it', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ success: true, request_id: 'req-1', credits_left: 73 })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ success: true, data: [{ first_name: 'Jane' }] })
+      ); // credits_left intentionally missing from poll
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = dropcontactEnrichNode.executor(
+      validInput,
+      makeContext({ dropcontact: { apiKey: 'test-key' } })
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.output?.creditsLeft).toBe(73);
+  });
+});
+
+// =============================================================================
+// executeNode integration (full engine path)
+// =============================================================================
+
+describe('executeNode integration', () => {
+  it('successful enrichment via executeNode validates output schema', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1', credits_left: 10 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: [
+            {
+              email: 'jane@example.com',
+              first_name: 'Jane',
+              last_name: 'Doe',
+              company: 'Acme',
+            },
+          ],
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ctx = makeContext({ dropcontact: { apiKey: 'test-key' } });
+    const promise = executeNode(dropcontactEnrichNode, validInput, ctx);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    // output should validate against DropcontactEnrichOutputSchema
+    const parsed = DropcontactEnrichOutputSchema.safeParse(result.output);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('engine-level timeout aborts polling', async () => {
+    // Use REAL timers because executeNode's Promise.race uses real setTimeout
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ success: true, request_id: 'req-1' }))
+      .mockResolvedValue(jsonResponse({ success: true })); // always pending
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ctx = makeContext({ dropcontact: { apiKey: 'test-key' } });
+    const result = await executeNode(dropcontactEnrichNode, validInput, ctx, { timeout: 50 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/timeout|timed out/i);
+  }, 10_000);
+
+  it('input schema validation throws ZodError via engine', async () => {
+    // executeNode calls inputSchema.parse() which throws on invalid input.
+    // This documents the engine's current behavior (no try/catch around parse).
+    const ctx = makeContext({ dropcontact: { apiKey: 'test-key' } });
+    await expect(
+      executeNode(
+        dropcontactEnrichNode,
+        // @ts-expect-error — deliberately bad input
+        { email: 'not-an-email' },
+        ctx
+      )
+    ).rejects.toThrow();
+  });
+});

--- a/packages/nodes/src/integrations/dropcontact/credentials.ts
+++ b/packages/nodes/src/integrations/dropcontact/credentials.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { defineApiKeyCredential } from '@jam-nodes/core';
+
+export const dropcontactCredential = defineApiKeyCredential({
+  name: 'dropcontact',
+  displayName: 'Dropcontact API',
+  documentationUrl: 'https://developer.dropcontact.io/',
+  schema: z.object({
+    apiKey: z.string().min(1, 'API key is required'),
+  }),
+  authenticate: {
+    type: 'header',
+    properties: {
+      'X-Access-Token': '{{apiKey}}',
+    },
+  },
+  testRequest: {
+    url: 'https://api.dropcontact.io/batch',
+    method: 'GET',
+  },
+});

--- a/packages/nodes/src/integrations/dropcontact/enrich.ts
+++ b/packages/nodes/src/integrations/dropcontact/enrich.ts
@@ -1,0 +1,232 @@
+import { defineNode } from '@jam-nodes/core';
+import { fetchWithRetry, sleep } from '../../utils/http.js';
+import {
+  DropcontactEnrichInputSchema,
+  DropcontactEnrichOutputSchema,
+  type DropcontactEnrichInput,
+  type DropcontactEnrichOutput,
+} from './schemas.js';
+
+const DROPCONTACT_API_BASE = 'https://api.dropcontact.io';
+const POLL_INTERVAL_MS = 5000;
+
+interface DropcontactSubmitResponse {
+  success?: boolean;
+  request_id?: string;
+  reason?: string;
+  error?: string | boolean;
+  credits_left?: number;
+}
+
+interface DropcontactPollResponse {
+  success?: boolean;
+  reason?: string;
+  error?: string | boolean;
+  credits_left?: number;
+  data?: unknown[];
+}
+
+function getString(obj: unknown, key: string): string | null {
+  if (typeof obj !== 'object' || obj === null) return null;
+  const value = (obj as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : null;
+}
+
+function errorMessage(body: { reason?: string; error?: string | boolean }, fallback: string): string {
+  if (typeof body.reason === 'string' && body.reason.length > 0) return body.reason;
+  if (typeof body.error === 'string' && body.error.length > 0) return body.error;
+  return fallback;
+}
+
+function buildSubmitBody(input: DropcontactEnrichInput): Record<string, unknown> {
+  const contact: Record<string, unknown> = {};
+  if (input.email !== undefined) contact['email'] = input.email;
+  if (input.firstName !== undefined) contact['first_name'] = input.firstName;
+  if (input.lastName !== undefined) contact['last_name'] = input.lastName;
+  if (input.fullName !== undefined) contact['full_name'] = input.fullName;
+  if (input.company !== undefined) contact['company'] = input.company;
+  if (input.website !== undefined) contact['website'] = input.website;
+  if (input.linkedinUrl !== undefined) contact['linkedin'] = input.linkedinUrl;
+  if (input.phone !== undefined) contact['phone'] = input.phone;
+
+  return {
+    data: [contact],
+    siren: input.siren,
+    language: input.language,
+  };
+}
+
+async function submitBatch(
+  apiKey: string,
+  input: DropcontactEnrichInput
+): Promise<{ requestId: string; creditsLeft: number | null }> {
+  const response = await fetchWithRetry(
+    `${DROPCONTACT_API_BASE}/batch`,
+    {
+      method: 'POST',
+      headers: {
+        'X-Access-Token': apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(buildSubmitBody(input)),
+    },
+    { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Dropcontact submit error: ${response.status} - ${text}`);
+  }
+
+  const body = (await response.json()) as DropcontactSubmitResponse;
+
+  if (body.success === false) {
+    throw new Error(errorMessage(body, 'Dropcontact submission failed'));
+  }
+
+  if (typeof body.request_id !== 'string' || body.request_id.length === 0) {
+    throw new Error('Dropcontact submit response missing request_id');
+  }
+
+  return {
+    requestId: body.request_id,
+    creditsLeft: typeof body.credits_left === 'number' ? body.credits_left : null,
+  };
+}
+
+async function getBatchResult(
+  apiKey: string,
+  requestId: string
+): Promise<DropcontactPollResponse> {
+  const url = `${DROPCONTACT_API_BASE}/batch/${encodeURIComponent(requestId)}?api_key=${encodeURIComponent(apiKey)}`;
+  const response = await fetchWithRetry(
+    url,
+    { method: 'GET' },
+    { maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Dropcontact poll error: ${response.status} - ${text}`);
+  }
+
+  return (await response.json()) as DropcontactPollResponse;
+}
+
+async function pollForResults(
+  apiKey: string,
+  requestId: string,
+  timeoutMs: number
+): Promise<{ record: unknown; creditsLeft: number | null }> {
+  const maxAttempts = Math.max(1, Math.ceil(timeoutMs / POLL_INTERVAL_MS));
+
+  // Fetch-first polling: poll immediately on attempt 0, then sleep between attempts.
+  // Sleep-first would waste the entire poll budget on `timeout: 1` (one attempt, spent sleeping).
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const body = await getBatchResult(apiKey, requestId);
+
+    if (body.success === false) {
+      throw new Error(errorMessage(body, 'Dropcontact enrichment failed'));
+    }
+
+    const hasData =
+      body.success === true && Array.isArray(body.data) && body.data.length > 0;
+
+    if (hasData) {
+      return {
+        record: (body.data as unknown[])[0],
+        creditsLeft: typeof body.credits_left === 'number' ? body.credits_left : null,
+      };
+    }
+
+    // Still processing. Sleep before the next attempt unless this was the last.
+    if (attempt < maxAttempts - 1) {
+      await sleep(POLL_INTERVAL_MS);
+    }
+  }
+
+  throw new Error(`Dropcontact polling timed out after ${Math.round(timeoutMs / 1000)}s`);
+}
+
+function mapEnrichedRecord(
+  raw: unknown,
+  requestId: string,
+  creditsLeft: number | null
+): DropcontactEnrichOutput {
+  return {
+    requestId,
+    success: true,
+    creditsLeft,
+    email: getString(raw, 'email'),
+    firstName: getString(raw, 'first_name'),
+    lastName: getString(raw, 'last_name'),
+    fullName: getString(raw, 'full_name'),
+    civility: getString(raw, 'civility'),
+    company: getString(raw, 'company'),
+    website: getString(raw, 'website'),
+    linkedin: getString(raw, 'linkedin'),
+    phone: getString(raw, 'phone'),
+    mobilePhone: getString(raw, 'mobile_phone'),
+    siren: getString(raw, 'siren'),
+  };
+}
+
+export {
+  DropcontactEnrichInputSchema,
+  DropcontactEnrichOutputSchema,
+  type DropcontactEnrichInput,
+  type DropcontactEnrichOutput,
+} from './schemas.js';
+
+/**
+ * Dropcontact Enrich Contact Node
+ *
+ * Submits a single contact to Dropcontact's async /batch endpoint and polls
+ * /batch/{request_id} until enrichment results are available or the timeout
+ * is reached. Returns the enriched contact fields with all unresolved fields
+ * set to `null`.
+ */
+export const dropcontactEnrichNode = defineNode({
+  type: 'dropcontact_enrich',
+  name: 'Dropcontact Enrich Contact',
+  description:
+    'Enrich a B2B contact via Dropcontact (GDPR-compliant). Submits to /batch and polls until results are ready.',
+  category: 'integration',
+  inputSchema: DropcontactEnrichInputSchema,
+  outputSchema: DropcontactEnrichOutputSchema,
+  estimatedDuration: 30,
+  capabilities: {
+    supportsRerun: true,
+  },
+
+  executor: async (input: DropcontactEnrichInput, context) => {
+    const apiKey = context.credentials?.dropcontact?.apiKey;
+    if (typeof apiKey !== 'string' || apiKey.length === 0) {
+      return {
+        success: false,
+        error:
+          'Dropcontact API key not configured. Please provide context.credentials.dropcontact.apiKey.',
+      };
+    }
+
+    try {
+      const { requestId, creditsLeft: submitCredits } = await submitBatch(apiKey, input);
+      const { record, creditsLeft: pollCredits } = await pollForResults(
+        apiKey,
+        requestId,
+        input.timeout * 1000
+      );
+
+      const creditsLeft = pollCredits ?? submitCredits;
+      const output = mapEnrichedRecord(record, requestId, creditsLeft);
+
+      return { success: true, output };
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Failed to enrich contact with Dropcontact',
+      };
+    }
+  },
+});

--- a/packages/nodes/src/integrations/dropcontact/index.ts
+++ b/packages/nodes/src/integrations/dropcontact/index.ts
@@ -1,0 +1,8 @@
+export { dropcontactEnrichNode } from './enrich.js';
+export {
+  DropcontactEnrichInputSchema,
+  DropcontactEnrichOutputSchema,
+  type DropcontactEnrichInput,
+  type DropcontactEnrichOutput,
+} from './schemas.js';
+export { dropcontactCredential } from './credentials.js';

--- a/packages/nodes/src/integrations/dropcontact/schemas.ts
+++ b/packages/nodes/src/integrations/dropcontact/schemas.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+export const DropcontactEnrichInputSchema = z.object({
+  email: z.string().email().optional(),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  fullName: z.string().optional(),
+  company: z.string().optional(),
+  website: z.string().optional(),
+  linkedinUrl: z.string().optional(),
+  phone: z.string().optional(),
+  language: z.enum(['en', 'fr']).default('en'),
+  siren: z.boolean().default(false),
+  timeout: z.number().int().positive().default(120),
+});
+
+export const DropcontactEnrichOutputSchema = z.object({
+  requestId: z.string(),
+  success: z.boolean(),
+  creditsLeft: z.number().nullable(),
+  email: z.string().nullable(),
+  firstName: z.string().nullable(),
+  lastName: z.string().nullable(),
+  fullName: z.string().nullable(),
+  civility: z.string().nullable(),
+  company: z.string().nullable(),
+  website: z.string().nullable(),
+  linkedin: z.string().nullable(),
+  phone: z.string().nullable(),
+  mobilePhone: z.string().nullable(),
+  siren: z.string().nullable(),
+});
+
+export type DropcontactEnrichInput = z.infer<typeof DropcontactEnrichInputSchema>;
+export type DropcontactEnrichOutput = z.infer<typeof DropcontactEnrichOutputSchema>;

--- a/packages/nodes/src/integrations/index.ts
+++ b/packages/nodes/src/integrations/index.ts
@@ -275,3 +275,13 @@ export {
   type SlackSearchMatch,
   slackCredential,
 } from './slack/index.js'
+
+// Dropcontact integrations
+export {
+  dropcontactEnrichNode,
+  DropcontactEnrichInputSchema,
+  DropcontactEnrichOutputSchema,
+  type DropcontactEnrichInput,
+  type DropcontactEnrichOutput,
+  dropcontactCredential,
+} from './dropcontact/index.js'


### PR DESCRIPTION
Closes #16

## Summary

Adds a `dropcontact_enrich` node that integrates the [Dropcontact API](https://developer.dropcontact.io/) for GDPR-compliant B2B contact enrichment. Dropcontact is asynchronous: `POST /batch` returns a `request_id`, and the client must poll `GET /batch/{request_id}` until enrichment results are ready.

The integration follows the existing Apify pattern for in-node polling and the existing Slack/WordPress patterns for credential handling, field mapping, and testing.

## Acceptance Criteria (from Issue #16)

- [x] Credential definition
- [x] Enrich operation
- [x] Async polling for results
- [x] Zod schemas
- [x] Unit tests

## What's in this PR

### New files

| File | Purpose |
|---|---|
| `packages/nodes/src/integrations/dropcontact/credentials.ts` | `dropcontactCredential` — apiKey type, `X-Access-Token` header auth, via `defineApiKeyCredential` from `@jam-nodes/core` |
| `packages/nodes/src/integrations/dropcontact/schemas.ts` | `DropcontactEnrichInputSchema` and `DropcontactEnrichOutputSchema` — fully typed with `z.infer<>`, no `z.any()` |
| `packages/nodes/src/integrations/dropcontact/enrich.ts` | `dropcontactEnrichNode` via `defineNode` — POST + polling loop, explicit field mapping |
| `packages/nodes/src/integrations/dropcontact/index.ts` | Barrel export for the integration |
| `packages/nodes/src/integrations/dropcontact/__tests__/dropcontact.test.ts` | 42 vitest tests |

### Modified files

| File | Change |
|---|---|
| `packages/core/src/types/node.ts` | Adds `dropcontact?: { apiKey: string }` to the `NodeCredentials` interface |
| `packages/nodes/src/integrations/index.ts` | Re-exports the new integration |
| `packages/nodes/src/index.ts` | Re-exports `dropcontactEnrichNode`, schemas, and credential; adds node to `builtInNodes` |

## Design decisions

### Polling lives inside the node, not the engine
Dropcontact's async submission → poll contract is API-specific, not a generic cross-cutting concern. The CLAUDE.md architectural note says retry/cache/timeout/rate-limiting belong in the execution engine's `ExecutionConfig`, but polling for an API-specific completion signal is different: it's the API's normal flow. This matches the existing Apify integration (`apify/run-actor.ts::pollUntilFinished`).

### Polling terminates on `data[0]` presence, NOT `success === true` alone
This is the highest-risk correctness issue in the integration. Dropcontact returns `success: true` on BOTH:
- the initial `POST /batch` (meaning "submission accepted"), and
- the final `GET /batch/{request_id}` when results are ready (meaning "enrichment complete")

A naive polling loop that exits on `success === true` would terminate on the first poll before any data is available. The implementation checks `body.success === true && Array.isArray(body.data) && body.data.length > 0` as the terminal success condition, with a dedicated regression test (`poll does NOT terminate on success:true with missing data`).

### Fetch-first polling order
The loop polls immediately on attempt 0 and only sleeps between attempts (skipping the sleep after the last attempt). This matches Apify's pattern and ensures the `timeout` input reflects real wall-clock semantics — a `timeout: 1` sends exactly one poll, rather than sleeping 5 seconds first with no budget left.

### `POLL_INTERVAL_MS = 5000` is a module constant
Not a user input — following the Apify pattern. Tests use `vi.useFakeTimers()` + `vi.runAllTimersAsync()` to fast-forward.

### Output mapping is explicit field-by-field
`mapEnrichedRecord` uses a private `getString(obj, key)` helper that returns `null` for missing keys, non-object values, or non-string field values. This:
- defends against the API returning missing keys without using `z.nullish()` (which would loosen the contract)
- implicitly strips extra undocumented fields from the Dropcontact response
- avoids any `as any` or `z.any()` (per CLAUDE.md)

### Output nullability is split
- `requestId` and `success` are **non-null** (control fields — always present on a valid result)
- `creditsLeft` is `.nullable()` (Dropcontact doesn't always include it)
- Enriched contact fields are all `.nullable()` (the API may resolve some fields but not others — a partial match is a valid, successful result)

### Single contact per call
Issue #16's input shape describes one contact per `dropcontactEnrich` invocation. Batching multiple contacts (with per-row error correlation) is deferred to a future issue if real workflows need it.

## Implementation details

### HTTP retry and error handling
Both the POST and the polling GETs use `fetchWithRetry` from `packages/nodes/src/utils/http.ts` with `{ maxRetries: 3, backoffMs: 1000, timeoutMs: 30000 }` (same config used by Slack and Apify). That helper handles:
- 401/403 → throws immediately, no retry (surfaced as `{ success: false, error }`)
- 429 with `Retry-After` → retries with the documented delay
- 5xx → retries with exponential backoff
- Network errors → retries with backoff
- Request timeout via `AbortController`

### Failure modes
Every failure path returns `{ success: false, error: "..." }` — the executor never throws. Credit exhaustion (`success: false` on POST) is surfaced via the `reason` field. Polling timeout surfaces as `Dropcontact polling timed out after Xs`.

### Credentials
- Adds `dropcontact?: { apiKey: string }` to the `NodeCredentials` type in `@jam-nodes/core`
- The executor checks `typeof apiKey !== 'string' || apiKey.length === 0` — missing credential object, missing `dropcontact` key, and empty-string `apiKey` all short-circuit to a clear error before any network request

### Submitted POST body
`buildSubmitBody` only includes fields the user supplied, so unset fields are never sent to Dropcontact as `undefined`. Field names are translated to Dropcontact's snake_case convention (`firstName` → `first_name`, `linkedinUrl` → `linkedin`, etc.).

## Test plan

All tests are offline (mocked `fetch` via `vi.stubGlobal`) — no real Dropcontact API calls during test runs.

### Test commands

```bash
# Run just the dropcontact tests
cd packages/nodes && npx vitest run src/integrations/dropcontact/__tests__/dropcontact.test.ts

# Run the full nodes test suite
npm test --workspace=@jam-nodes/nodes
```

### Results

- **Dropcontact tests**: **42 / 42 passing**
- **Full nodes suite**: **237 / 237 passing** (195 pre-existing + 42 new, zero regressions)
- **Core typecheck**: passes
- **Nodes typecheck**: unchanged error count vs main (pre-existing errors in `slack/*` and `google-sheets/*` are not introduced or affected by this PR)

### Coverage breakdown

| Describe block | Tests | Covers |
|---|---:|---|
| `dropcontact credential` | 4 | Metadata, schema accepts/rejects apiKey (valid, empty, missing) |
| `dropcontact schemas` | 11 | Input validation (all fields, defaults, invalid email, empty email, invalid language, zero timeout, negative timeout), output validation (accepts nulls, rejects missing/null requestId, rejects missing success) |
| `dropcontactEnrichNode` | 24 | Metadata; missing/empty/wrong credentials (3 distinct paths); POST URL/headers/body shape; POST body filtering; polling to `data[0]`; polling regression for `success:true` without data; `success:false` termination; credit exhaustion on POST; URL encoding of `request_id` and `api_key`; snake_case → camelCase mapping; missing fields → null; extra fields stripped; empty `data:[]`; all-null `data[0]`; polling timeout; 401; 5xx; network error mid-poll; 429 during polling; non-string field values → null; `request_id` missing from 2xx success; `creditsLeft` preservation |
| `executeNode integration` | 3 | Full engine path (schema validation, timeout, happy path) |